### PR TITLE
chore: release number_flow 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-07-12
+
+### Changed
+- Updated Rails-related lockfile dependencies, RuboCop, and Minitest.
+
 ## [0.1.1] - 2026-07-12
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    number_flow (0.1.1)
+    number_flow (0.1.2)
       actionview (>= 8.1.0)
       railties (>= 8.1.0)
 
@@ -283,7 +283,7 @@ CHECKSUMS
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
   nokogiri (1.19.2-arm64-darwin) sha256=58d8ea2e31a967b843b70487a44c14c8ba1866daa1b9da9be9dbdf1b43dee205
   nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
-  number_flow (0.1.1)
+  number_flow (0.1.2)
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.2) sha256=6f60c84aa4bdcedb6d1a2434b738fe8a8136807b6adc8f7f53b97da9bc4e9357
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6

--- a/lib/number_flow/version.rb
+++ b/lib/number_flow/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NumberFlow
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
## Summary
- Bump `number_flow` from 0.1.1 to 0.1.2.
- Record dependency-maintenance changes in `CHANGELOG.md`.
- Refresh the lockfile's local gem version.

## Verification
- `bundle exec rake` — 12 runs, 63 assertions, 0 failures, 0 errors, 0 skips.
- RuboCop — 12 files inspected, no offenses.
- `bundle exec rake build` — built `pkg/number_flow-0.1.2.gem`.

This PR is intentionally not merged or published by this task.