### PR TITLE
feat: Address open issues #1-#7 (decimals, locale, CI, Vite, ViewComponent, browser tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,15 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true
 
-      - name: Set up Chrome
+      - name: Install Chrome
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome: stable
+          chrome: 136
         id: setup-chrome
 
       - name: Set Chrome binary path
-        run: echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+        run: |
+          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
 
       - name: Run system tests
         run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Tests + Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+
+      - name: Run RuboCop
+        run: bundle exec rubocop
+
+  system:
+    name: Browser System Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Set up Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome: stable
+        id: setup-chrome
+
+      - name: Set Chrome binary path
+        run: echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+
+      - name: Run system tests
+        run: bundle exec rake test
+        env:
+          RUN_SYSTEM_TESTS: "true"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,27 @@ Metrics/MethodLength:
   Exclude:
     - 'test/**/*'
 
-Metrics/ParameterLists:
-  Max: 10
+Metrics/ModuleLength:
+  Max: 130
+  Exclude:
+    - 'test/**/*'
 
+Metrics/ClassLength:
+  Max: 150
+  Exclude:
+    - 'test/**/*'
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/ParameterLists:
+  Max: 11
+
+Layout/LineLength:
+  Exclude:
+    - 'test/system/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,10 @@ gem 'rake', '~> 13.0'
 gem 'minitest', '~> 6.0'
 gem 'rails', '>= 8.1.0'
 gem 'rubocop', '~> 1.86'
+
+group :test do
+  gem 'capybara'
+  gem 'cuprite'
+  gem 'view_component', require: false
+  gem 'webrick'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,17 +82,37 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.0.1)
     builder (3.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
+    cuprite (0.17)
+      capybara (~> 3.0)
+      ferrum (~> 0.17.0)
     date (3.5.1)
     drb (2.2.3)
     erb (6.0.2)
     erubi (1.13.1)
+    ferrum (0.17.2)
+      addressable (~> 2.5)
+      base64 (~> 0.2)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -117,6 +137,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.1.0)
+    matrix (0.4.3)
     mini_mime (1.1.5)
     minitest (6.0.2)
       drb (~> 2.0)
@@ -146,6 +167,7 @@ GEM
     psych (5.3.1)
       date
       stringio
+    public_suffix (7.0.5)
     racc (1.8.1)
     rack (3.2.5)
     rack-session (2.1.1)
@@ -221,10 +243,17 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
+    view_component (4.12.0)
+      actionview (>= 7.1.0)
+      activesupport (>= 7.1.0)
+      concurrent-ruby (~> 1)
+    webrick (1.9.2)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.7.4)
 
 PLATFORMS
@@ -232,12 +261,16 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  capybara
+  cuprite
   irb
   minitest (~> 6.0)
   number_flow!
   rails (>= 8.1.0)
   rake (~> 13.0)
   rubocop (~> 1.86)
+  view_component
+  webrick
 
 CHECKSUMS
   action_text-trix (2.1.17) sha256=b44691639d77e67169dc054ceacd1edc04d44dc3e4c6a427aa155a2beb4cc951
@@ -252,17 +285,21 @@ CHECKSUMS
   activerecord (8.1.2.1) sha256=3f79140318ff6d23376f5d9b1b5b5e2c7d3cc8979dd71367e9a8394378ca630a
   activestorage (8.1.2.1) sha256=36794c9b8853ac9276b0386cb1f8973374d8e71e8a9666bb02e70f5b7c9c5391
   activesupport (8.1.2.1) sha256=beec20ced12ad569194554399449a6372fdab03061b8f48a9ed6ef9b7dc251b2
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  cuprite (0.17) sha256=b140d5dc70d08b97ad54bcf45cd95d0bd430e291e9dffe76fff851fddd57c12b
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
+  ferrum (0.17.2) sha256=2c2540a850b211a46f4d81de21bfd62048f507e4c327d1807225c3823c17e6ee
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
@@ -274,6 +311,7 @@ CHECKSUMS
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
+  matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
@@ -290,6 +328,7 @@ CHECKSUMS
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.5) sha256=4cbd0974c0b79f7a139b4812004a62e4c60b145cba76422e288ee670601ed6d3
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
@@ -317,8 +356,11 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  view_component (4.12.0) sha256=b9a5979d1c43eba2aa21a06a86f661aab3990104855f2909ef7c3779acdcdcb4
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
+  xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # NumberFlow
 
-Rails helper + Stimulus controller for smooth integer digit transitions inspired by [number-flow](https://github.com/barvian/number-flow).
+Rails helper + Stimulus controller for smooth number digit transitions (integers, decimals, locale-aware) inspired by [number-flow](https://github.com/barvian/number-flow).
 
+[![CI](https://github.com/dpaluy/number_flow/actions/workflows/ci.yml/badge.svg)](https://github.com/dpaluy/number_flow/actions/workflows/ci.yml)
 [![Gem Version](https://badge.fury.io/rb/number_flow.svg)](https://badge.fury.io/rb/number_flow)
 
 `number_flow` ships both CSS and JavaScript assets inside the gem, so you do not need a separate npm package.
@@ -37,6 +38,8 @@ Add this in your layout (or import into your main stylesheet):
 
 ### 2) Register the Stimulus controller
 
+#### Sprockets / Importmap
+
 With importmap (`config/importmap.rb`):
 
 ```ruby
@@ -52,25 +55,56 @@ import NumberFlowController from "number_flow/controller"
 application.register("number-flow", NumberFlowController)
 ```
 
+#### Vite Rails
+
+Use the built-in generator to copy assets into `app/frontend/`:
+
+```sh
+rails g number_flow:install --vite
+```
+
+This copies:
+- `controller.js` → `app/frontend/controllers/number_flow_controller.js`
+- `number_flow.css` → `app/frontend/stylesheets/number_flow.css`
+
+If `app/frontend/entrypoints/application.js` exists, the controller import and registration are appended automatically (idempotent — re-running won't duplicate).
+
+Without `--vite`, the generator prints the Sprockets/importmap setup instructions above.
+
 ## Usage
 
-Render a value:
+Render an integer:
 
 ```erb
 <%= number_flow_tag(12_345) %>
+```
+
+Render a decimal with precision:
+
+```erb
+<%= number_flow_tag(12.34, precision: 2) %>
+```
+
+Locale-aware formatting (uses `Intl.NumberFormat` on the client):
+
+```erb
+<%= number_flow_tag(1234.5, precision: 1, locale: "de-DE", grouping: true) %>
+<!-- renders as 1.234,5 -->
 ```
 
 Render with options:
 
 ```erb
 <%= number_flow_tag(
-  12_345,
+  12_345.67,
+  precision: 2,
   class: "kpi-value",
   duration: 550,
   easing: "ease-out",
   stagger: 30,
   grouping: true,
-  aria_label: "Current total users"
+  locale: "en-US",
+  aria_label: "Current total revenue"
 ) %>
 ```
 
@@ -80,7 +114,7 @@ Update from JavaScript:
 const element = document.querySelector("[data-controller='number-flow']")
 element.dispatchEvent(
   new CustomEvent("number-flow:update", {
-    detail: { value: 12987 }
+    detail: { value: 12987.50 }
   })
 )
 ```
@@ -96,8 +130,20 @@ Options:
 - `easing:` CSS easing function (default: `cubic-bezier(0.2, 0, 0, 1)`)
 - `stagger:` per-digit delay in milliseconds (default: `20`)
 - `grouping:` show thousands separators (default: `false`)
+- `precision:` number of decimal digits (default: `0` — integer mode)
+- `locale:` BCP 47 locale tag for formatting (default: `nil` → browser default)
 - `aria_label:` explicit `aria-label`
 - `data:` additional data attributes merged into the root element
+
+## Optional ViewComponent Wrapper
+
+If your app uses [ViewComponent](https://github.com/github/view_component), `NumberFlow::Component` is available as a thin wrapper:
+
+```erb
+<%= render(NumberFlow::Component.new(value: 42, precision: 2)) %>
+```
+
+The component is only defined when the `view_component` gem is present. The gem does **not** add `view_component` as a runtime dependency. Add it to your app's Gemfile to use the component API.
 
 ## Accessibility
 
@@ -106,13 +152,29 @@ Options:
 
 ## Error Handling
 
-`number_flow_tag` raises `ArgumentError` when `value` cannot be coerced into an integer.
+`number_flow_tag` raises `ArgumentError` when `value` cannot be coerced into a numeric value.
+
+## Why No npm Package?
+
+**Decision: gem-only distribution.** The Stimulus controller consumes data attributes (`data-number-flow-value-value`, `data-number-flow-precision-value`, etc.) that are emitted by the Ruby helper. The JS is not standalone — it depends on the gem's markup contract. Publishing to npm would:
+
+1. **Double maintenance** for no standalone value — two version tracks, two release workflows, two changelogs.
+2. **Not solve a real problem** — Vite/importmap integration (via the install generator) already covers asset resolution without npm.
+3. **Conflict with positioning** — the gem already markets gem-only as a feature.
+
+**Revisit trigger:** if a framework-agnostic core (pure formatting + DOM, no Rails-helper coupling) is extracted, or if community demand materializes for importing the controller from `@dpaluy/number_flow` in a non-Rails context. Until then: won't ship.
 
 ## Development
 
 ```sh
 bundle exec rake test
 bundle exec rubocop
+```
+
+Browser system tests require Chrome/Chromium:
+
+```sh
+RUN_SYSTEM_TESTS=true bundle exec rake test
 ```
 
 ## Contributing

--- a/app/assets/javascripts/number_flow/controller.js
+++ b/app/assets/javascripts/number_flow/controller.js
@@ -8,7 +8,9 @@ export default class extends Controller {
     duration: Number,
     easing: String,
     stagger: Number,
-    grouping: Boolean
+    grouping: Boolean,
+    precision: Number,
+    locale: String
   }
 
   connect() {
@@ -41,41 +43,33 @@ export default class extends Controller {
       return
     }
 
-    this.updateTo(Math.trunc(nextValue))
+    this.updateTo(nextValue)
   }
 
   updateTo(nextValue) {
-    const normalized = Math.trunc(nextValue)
-    if (normalized === this.currentValue) return
+    if (nextValue === this.currentValue) return
+    if (!this.currentParts) return // Guard: not yet connected
 
     this.applyTimingVariables()
-    this.render(normalized, !this.prefersReducedMotion())
-    this.currentValue = normalized
-    this.valueValue = normalized
+    this.render(nextValue, !this.prefersReducedMotion())
+    this.currentValue = nextValue
+    this.valueValue = nextValue
   }
 
   render(value, animate) {
-    const previousDigits = this.currentParts.filter((part) => part.kind === "digit").map((part) => part.value)
+    const previousParts = this.currentParts
     const nextParts = this.partsFor(value)
-    const nextDigits = nextParts.filter((part) => part.kind === "digit").map((part) => part.value)
-
-    let digitIndex = 0
-    const totalDigits = nextDigits.length
     const fragment = document.createDocumentFragment()
 
-    nextParts.forEach((part) => {
+    nextParts.forEach((part, index) => {
       if (part.kind === "separator") {
         fragment.appendChild(this.buildSeparatorNode(part.value))
         return
       }
 
-      const remaining = totalDigits - digitIndex
-      const previousIndex = previousDigits.length - remaining
-      const fromDigit = previousIndex >= 0 ? previousDigits[previousIndex] : 0
-      const toDigit = part.value
-      const indexFromRight = totalDigits - digitIndex - 1
-      fragment.appendChild(this.buildDigitNode(fromDigit, toDigit, indexFromRight, animate))
-      digitIndex += 1
+      const { fromDigit } = this.alignDigit(previousParts, nextParts, index)
+      const indexFromRight = nextParts.length - index - 1
+      fragment.appendChild(this.buildDigitNode(fromDigit, part.value, indexFromRight, animate))
     })
 
     this.element.replaceChildren(fragment)
@@ -92,6 +86,20 @@ export default class extends Controller {
     this.currentParts = nextParts
   }
 
+  alignDigit(previousParts, nextParts, currentIndex) {
+    const nextDigits = nextParts.filter((p) => p.kind === "digit")
+    const previousDigits = previousParts.filter((p) => p.kind === "digit")
+
+    const currentDigitIndex = nextParts.slice(0, currentIndex).filter((p) => p.kind === "digit").length
+    const remaining = nextDigits.length - currentDigitIndex
+    const previousIndex = previousDigits.length - remaining
+
+    const fromDigit = previousIndex >= 0 ? previousDigits[previousIndex].value : 0
+    const toDigit = nextParts[currentIndex].value
+
+    return { fromDigit, toDigit }
+  }
+
   partsFor(value) {
     return this.formattedString(value).split("").map((char) => {
       if (/\d/.test(char)) {
@@ -103,10 +111,14 @@ export default class extends Controller {
   }
 
   formattedString(value) {
-    const sign = value < 0 ? "-" : ""
-    const digits = Math.abs(value).toString()
-    const groupedDigits = this.groupingValue ? digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",") : digits
-    return `${sign}${groupedDigits}`
+    const formatter = new Intl.NumberFormat(this.localeValue || undefined, {
+      useGrouping: this.groupingValue,
+      minimumFractionDigits: this.precisionValue,
+      maximumFractionDigits: this.precisionValue
+    })
+
+    const formatted = formatter.format(Math.abs(value))
+    return value < 0 ? `-${formatted}` : formatted
   }
 
   buildDigitNode(fromDigit, toDigit, indexFromRight, animate) {
@@ -150,19 +162,19 @@ export default class extends Controller {
 
   initialValue() {
     if (this.hasValueValue && Number.isFinite(this.valueValue)) {
-      return Math.trunc(this.valueValue)
+      return this.valueValue
     }
 
     const inlineValue = Number(this.element.getAttribute("data-number-flow-value-value"))
     if (Number.isFinite(inlineValue)) {
-      return Math.trunc(inlineValue)
+      return inlineValue
     }
 
     return 0
   }
 
   prefersReducedMotion() {
-    return this.reducedMotionMedia.matches
+    return this.reducedMotionMedia?.matches === true
   }
 
   durationOrDefault() {
@@ -170,7 +182,7 @@ export default class extends Controller {
   }
 
   easingOrDefault() {
-    return this.hasEasingValue ? this.easingValue : "cubic-bezier(0.2, 0, 0, 1)"
+    return this.hasEasingValue ? this.easingValue : "cubic-bezier(0.2, 0, 1)"
   }
 
   staggerOrDefault() {
@@ -181,4 +193,3 @@ export default class extends Controller {
     return typeof document !== "undefined" && document.location?.hostname === "localhost"
   }
 }
-

--- a/app/components/number_flow/component.rb
+++ b/app/components/number_flow/component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'number_flow/helper'
+
+begin
+  require 'view_component'
+rescue LoadError
+  # ViewComponent is not installed — Component is not defined.
+end
+
+module NumberFlow
+  # Optional ViewComponent wrapper around the +number_flow_tag+ helper.
+  # Only defined when the +view_component+ gem is available, so the gem
+  # never forces a hard dependency.
+  if defined?(::ViewComponent)
+    class Component < ::ViewComponent::Base
+      include NumberFlow::Helper
+
+      def initialize(value:, **options)
+        @value = value
+        @options = options
+        super()
+      end
+
+      def call
+        number_flow_tag(@value, **@options)
+      end
+    end
+  end
+end

--- a/lib/generators/number_flow/install/install_generator.rb
+++ b/lib/generators/number_flow/install/install_generator.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails/generators'
+require 'rails/generators/base'
+
+module NumberFlow
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      desc 'Install NumberFlow for your asset pipeline (Sprockets, importmap, or Vite Rails).'
+
+      class_option :vite, type: :boolean, default: false,
+                          desc: 'Copy controller and stylesheet into app/frontend for Vite Rails'
+
+      source_root File.expand_path('../../../..', __dir__)
+
+      CONTROLLER_SOURCE = 'app/assets/javascripts/number_flow/controller.js'
+      CSS_SOURCE = 'app/assets/stylesheets/number_flow.css'
+      VITE_CONTROLLER_TARGET = 'app/frontend/controllers/number_flow_controller.js'
+      VITE_CSS_TARGET = 'app/frontend/stylesheets/number_flow.css'
+      VITE_ENTRYPOINT = 'app/frontend/entrypoints/application.js'
+
+      def install
+        if options[:vite]
+          install_vite
+        else
+          install_standard
+        end
+      end
+
+      private
+
+      def install_vite
+        say_status('info', 'Installing NumberFlow for Vite Rails', :blue)
+
+        copy_file(CONTROLLER_SOURCE, VITE_CONTROLLER_TARGET)
+        copy_file(CSS_SOURCE, VITE_CSS_TARGET)
+        register_stimulus_controller
+      end
+
+      def install_standard
+        say_status('info', 'NumberFlow assets are served from the gem (Sprockets/importmap).', :blue)
+        say('')
+        say('1. Load the stylesheet in your layout:')
+        say('   <%= stylesheet_link_tag "number_flow", "data-turbo-track": "reload" %>')
+        say('')
+        say('2. Pin the controller (config/importmap.rb):')
+        say('   pin "number_flow/controller", to: "number_flow/controller.js"')
+        say('')
+        say('3. Register in app/javascript/controllers/index.js:')
+        say('   import NumberFlowController from "number_flow/controller"')
+        say('   application.register("number-flow", NumberFlowController)')
+      end
+
+      def register_stimulus_controller
+        return unless File.exist?(File.expand_path(VITE_ENTRYPOINT, destination_root))
+
+        entrypoint_path = File.expand_path(VITE_ENTRYPOINT, destination_root)
+        content = File.read(entrypoint_path)
+
+        import_line = 'import NumberFlowController from "../controllers/number_flow_controller"'
+        register_line = 'application.register("number-flow", NumberFlowController)'
+
+        return if content.include?(import_line)
+
+        inject_into_file(VITE_ENTRYPOINT, "  #{import_line}\n", after: /import application from.*\n/)
+
+        unless content.include?(register_line)
+          inject_into_file(VITE_ENTRYPOINT, "  #{register_line}\n",
+                           after: /application = Application\.start.*\n/)
+        end
+
+        say_status('create', "#{VITE_ENTRYPOINT} (updated)", :green)
+      end
+    end
+  end
+end

--- a/lib/number_flow.rb
+++ b/lib/number_flow.rb
@@ -19,7 +19,7 @@ end
 # Load Rails generators when Rails is available.
 begin
   require 'rails'
-  require_relative '../generators/number_flow/install/install_generator'
+  require_relative 'generators/number_flow/install/install_generator'
 rescue LoadError
   # Rails is not available — generators are not loaded.
 end

--- a/lib/number_flow.rb
+++ b/lib/number_flow.rb
@@ -7,3 +7,19 @@ require_relative 'number_flow/engine'
 module NumberFlow
   class Error < StandardError; end
 end
+
+# Load optional ViewComponent wrapper if the gem is present.
+begin
+  require 'view_component'
+  require_relative '../app/components/number_flow/component'
+rescue LoadError
+  # ViewComponent is not installed — Component stays undefined.
+end
+
+# Load Rails generators when Rails is available.
+begin
+  require 'rails'
+  require_relative '../generators/number_flow/install/install_generator'
+rescue LoadError
+  # Rails is not available — generators are not loaded.
+end

--- a/lib/number_flow/helper.rb
+++ b/lib/number_flow/helper.rb
@@ -14,12 +14,14 @@ module NumberFlow
       easing: DEFAULT_EASING,
       stagger: DEFAULT_STAGGER,
       grouping: false,
+      precision: 0,
+      locale: nil,
       aria_label: nil,
       data: {},
       **html_options
     )
-      normalized_value = Integer(value)
-      formatted_value = format_integer(normalized_value, grouping: grouping)
+      normalized_value = coerce_number(value)
+      formatted_value = format_number(normalized_value, precision: precision, grouping: grouping, locale: locale)
       css_class = html_options.delete(:class)
       extra_data = html_options.delete(:data)
 
@@ -38,7 +40,9 @@ module NumberFlow
             number_flow_duration_value: Integer(duration),
             number_flow_easing_value: easing.to_s,
             number_flow_stagger_value: Integer(stagger),
-            number_flow_grouping_value: grouping == true
+            number_flow_grouping_value: grouping == true,
+            number_flow_precision_value: Integer(precision),
+            number_flow_locale_value: locale
           },
           normalize_data_hash(data),
           normalize_data_hash(extra_data)
@@ -49,10 +53,21 @@ module NumberFlow
         safe_join(formatted_value.chars.map { |char| build_character_fragment(char) })
       end
     rescue ArgumentError, TypeError
-      raise ArgumentError, 'number_flow_tag expects an integer-compatible value'
+      raise ArgumentError, 'number_flow_tag expects a numeric value'
     end
 
     private
+
+    def coerce_number(value)
+      case value
+      when Integer, Float
+        value
+      when String
+        Float(value)
+      else
+        value.respond_to?(:to_f) ? Float(value.to_f) : (raise ArgumentError)
+      end
+    end
 
     def build_character_fragment(char)
       if char.match?(/\d/)
@@ -80,11 +95,40 @@ module NumberFlow
       end
     end
 
-    def format_integer(value, grouping:)
+    def format_number(value, precision:, grouping:, locale:)
       sign = value.negative? ? '-' : ''
-      digits = value.abs.to_s
-      grouped = grouping ? digits.reverse.scan(/.{1,3}/).join(',').reverse : digits
-      "#{sign}#{grouped}"
+      abs_value = value.abs
+      decimal_sep = locale_decimal_separator(locale)
+      group_sep = locale_group_separator(locale)
+
+      if precision.positive?
+        integer_part = Integer(abs_value.floor)
+        fraction = format('%.0f', (abs_value - integer_part) * (10**precision)).rjust(precision, '0')
+        number_str = "#{group_digits(integer_part, grouping, group_sep)}#{decimal_sep}#{fraction}"
+      else
+        number_str = group_digits(Integer(abs_value), grouping, group_sep)
+      end
+
+      "#{sign}#{number_str}"
+    end
+
+    def group_digits(integer, grouping, separator)
+      digits = integer.to_s
+      return digits unless grouping
+
+      digits.reverse.scan(/.{1,3}/).join(separator).reverse
+    end
+
+    def locale_decimal_separator(locale)
+      return ',' if locale && !locale.start_with?('en')
+
+      '.'
+    end
+
+    def locale_group_separator(locale)
+      return '.' if locale && !locale.start_with?('en')
+
+      ','
     end
 
     def merged_data_attributes(*hashes)

--- a/lib/number_flow/helper.rb
+++ b/lib/number_flow/helper.rb
@@ -41,7 +41,7 @@ module NumberFlow
             number_flow_easing_value: easing.to_s,
             number_flow_stagger_value: Integer(stagger),
             number_flow_grouping_value: grouping == true,
-            number_flow_precision_value: Integer(precision),
+            number_flow_precision_value: precision.positive? ? Integer(precision) : nil,
             number_flow_locale_value: locale
           },
           normalize_data_hash(data),

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+module NumberFlow
+  class ComponentTest < Minitest::Test
+    include NumberFlowTestSupport
+
+    def test_component_defined_when_view_component_present
+      # view_component is in the test group, so it should be loaded.
+      assert defined?(::ViewComponent), 'view_component gem should be present in test'
+      assert defined?(NumberFlow::Component), 'NumberFlow::Component should be defined'
+    end
+
+    def test_component_renders_same_markup_as_helper
+      helper_html = build_view.number_flow_tag(42, precision: 2)
+
+      component = NumberFlow::Component.new(value: 42, precision: 2)
+      component_html = component.call
+
+      assert_equal helper_html, component_html
+    end
+
+    def test_component_supports_all_options
+      helper_html = build_view.number_flow_tag(
+        12.34, precision: 2, locale: 'de-DE', grouping: true, duration: 800
+      )
+
+      component = NumberFlow::Component.new(
+        value: 12.34, precision: 2, locale: 'de-DE', grouping: true, duration: 800
+      )
+      component_html = component.call
+
+      assert_equal helper_html, component_html
+    end
+
+    def test_component_works_with_integer
+      helper_html = build_view.number_flow_tag(1234)
+
+      component = NumberFlow::Component.new(value: 1234)
+      assert_equal helper_html, component.call
+    end
+  end
+end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'rails'
+require 'action_controller/railtie'
+require 'rails/generators'
+require 'rails/generators/test_case'
+require 'tmpdir'
+require 'fileutils'
+
+require File.expand_path('../../lib/generators/number_flow/install/install_generator', __dir__)
+
+module NumberFlow
+  class InstallGeneratorTest < Rails::Generators::TestCase
+    tests NumberFlow::Generators::InstallGenerator
+    destination File.join(Dir.mktmpdir, 'vite_sandbox')
+    setup :prepare_destination
+
+    def setup
+      super
+      FileUtils.mkdir_p(File.join(destination_root, 'app/frontend/controllers'))
+      FileUtils.mkdir_p(File.join(destination_root, 'app/frontend/stylesheets'))
+      FileUtils.mkdir_p(File.join(destination_root, 'app/frontend/entrypoints'))
+      FileUtils.mkdir_p(File.join(destination_root, 'app/assets/javascripts/number_flow'))
+      FileUtils.mkdir_p(File.join(destination_root, 'app/assets/stylesheets'))
+    end
+
+    def source_paths
+      [File.expand_path('../../..', __dir__)]
+    end
+
+    def test_vite_install_copies_controller_and_css
+      run_generator %w[--vite]
+
+      assert_file File.join(destination_root, 'app/frontend/controllers/number_flow_controller.js') do |content|
+        assert_includes content, 'import { Controller } from "@hotwired/stimulus"'
+        assert_includes content, 'precision'
+        assert_includes content, 'Intl.NumberFormat'
+      end
+
+      assert_file File.join(destination_root, 'app/frontend/stylesheets/number_flow.css') do |content|
+        assert_includes content, '.nf'
+      end
+    end
+
+    def test_vite_install_appends_to_entrypoint
+      entrypoint = File.join(destination_root, 'app/frontend/entrypoints/application.js')
+      File.write(entrypoint, %(import application from "../application.js"\napplication = Application.start()\n))
+
+      run_generator %w[--vite]
+
+      content = File.read(entrypoint)
+      assert_includes content, 'import NumberFlowController from "../controllers/number_flow_controller"'
+      assert_includes content, 'application.register("number-flow", NumberFlowController)'
+    end
+
+    def test_vite_install_is_idempotent
+      entrypoint = File.join(destination_root, 'app/frontend/entrypoints/application.js')
+      File.write(entrypoint, %(import application from "../application.js"\napplication = Application.start()\n))
+
+      run_generator %w[--vite]
+      run_generator %w[--vite]
+
+      content = File.read(entrypoint)
+      import_count = content.scan('import NumberFlowController').length
+      register_count = content.scan('application.register("number-flow"').length
+
+      assert_equal 1, import_count, 'Generator should not duplicate import line on re-run'
+      assert_equal 1, register_count, 'Generator should not duplicate register line on re-run'
+    end
+
+    def test_vite_install_does_not_require_entrypoint
+      entrypoint = File.join(destination_root, 'app/frontend/entrypoints/application.js')
+      FileUtils.rm_f(entrypoint)
+
+      run_generator %w[--vite]
+
+      assert_file 'app/frontend/controllers/number_flow_controller.js'
+      refute File.exist?(entrypoint), 'Should not create entrypoint if missing'
+    end
+
+    def test_standard_install_does_not_copy_files
+      run_generator []
+
+      refute File.exist?(File.join(destination_root, 'app/frontend/controllers/number_flow_controller.js'))
+      refute File.exist?(File.join(destination_root, 'app/frontend/stylesheets/number_flow.css'))
+    end
+  end
+end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -8,7 +8,10 @@ require 'rails/generators/test_case'
 require 'tmpdir'
 require 'fileutils'
 
-require File.expand_path('../../lib/generators/number_flow/install/install_generator', __dir__)
+# Do NOT directly require the generator file here.
+# The generator must be loaded via require 'number_flow' (already done in
+# test_helper), which exercises the real load path in lib/number_flow.rb.
+# This test catches dead require_relative paths.
 
 module NumberFlow
   class InstallGeneratorTest < Rails::Generators::TestCase
@@ -84,6 +87,14 @@ module NumberFlow
 
       refute File.exist?(File.join(destination_root, 'app/frontend/controllers/number_flow_controller.js'))
       refute File.exist?(File.join(destination_root, 'app/frontend/stylesheets/number_flow.css'))
+    end
+
+    # Regression test: lib/number_flow.rb must load the generator via the
+    # correct require_relative path so it is available after require 'number_flow'.
+    # This catches dead path bugs (e.g. '../generators' instead of 'generators').
+    def test_generator_loaded_via_require_number_flow
+      assert defined?(NumberFlow::Generators::InstallGenerator),
+             'NumberFlow::Generators::InstallGenerator must be defined after require \'number_flow\''
     end
   end
 end

--- a/test/number_flow/controller_contract_test.rb
+++ b/test/number_flow/controller_contract_test.rb
@@ -12,5 +12,20 @@ module NumberFlow
       assert_includes source, 'prefers-reduced-motion'
       assert_includes source, 'grouping'
     end
+
+    def test_controller_supports_decimal_precision
+      source = File.read(File.expand_path('../../app/assets/javascripts/number_flow/controller.js', __dir__))
+
+      assert_includes source, 'precision'
+      assert_includes source, 'minimumFractionDigits'
+      assert_includes source, 'maximumFractionDigits'
+    end
+
+    def test_controller_supports_locale
+      source = File.read(File.expand_path('../../app/assets/javascripts/number_flow/controller.js', __dir__))
+
+      assert_includes source, 'locale'
+      assert_includes source, 'Intl.NumberFormat'
+    end
   end
 end

--- a/test/number_flow/helper_test.rb
+++ b/test/number_flow/helper_test.rb
@@ -73,12 +73,74 @@ module NumberFlow
       assert_includes html, 'id="counter"'
     end
 
-    def test_raises_on_non_integer_value
+    def test_raises_on_non_numeric_value
       error = assert_raises(ArgumentError) do
         build_view.number_flow_tag('invalid')
       end
 
-      assert_includes error.message, 'integer-compatible'
+      assert_includes error.message, 'numeric value'
+    end
+
+    def test_renders_decimal_value
+      html = build_view.number_flow_tag(12.34, precision: 2)
+
+      assert_includes html, 'data-number-flow-value-value="12.34"'
+      assert_includes html, 'data-number-flow-precision-value="2"'
+      assert_includes html, 'aria-label="12.34"'
+      assert_includes html, 'nf__separator'
+      assert_includes html, 'data-digit="1"'
+      assert_includes html, 'data-digit="2"'
+    end
+
+    def test_decimal_with_precision_pads_zeros
+      html = build_view.number_flow_tag(10, precision: 2)
+
+      assert_includes html, 'aria-label="10.00"'
+      assert_includes html, 'data-number-flow-precision-value="2"'
+    end
+
+    def test_negative_decimal_value
+      html = build_view.number_flow_tag(-3.5, precision: 1)
+
+      assert_includes html, 'data-number-flow-value-value="-3.5"'
+      assert_includes html, 'aria-label="-3.5"'
+      assert_includes html, 'data-digit="3"'
+    end
+
+    def test_integer_regression_byte_identical
+      html = build_view.number_flow_tag(1234)
+
+      assert_includes html, 'data-number-flow-value-value="1234"'
+      assert_includes html, 'data-number-flow-precision-value="0"'
+      assert_includes html, 'aria-label="1234"'
+    end
+
+    def test_locale_option_emits_data_attribute
+      html = build_view.number_flow_tag(1234.5, precision: 1, locale: 'de-DE', grouping: true)
+
+      assert_includes html, 'data-number-flow-locale-value="de-DE"'
+      assert_includes html, 'data-number-flow-precision-value="1"'
+      assert_includes html, 'aria-label="1.234,5"'
+    end
+
+    def test_locale_en_us_grouping
+      html = build_view.number_flow_tag(1234.5, precision: 1, locale: 'en-US', grouping: true)
+
+      assert_includes html, 'data-number-flow-locale-value="en-US"'
+      assert_includes html, 'aria-label="1,234.5"'
+    end
+
+    def test_locale_nil_omits_data_attribute
+      html = build_view.number_flow_tag(1234)
+
+      refute_includes html, 'data-number-flow-locale-value'
+    end
+
+    def test_nine_nine_nine_rollover_format
+      html = build_view.number_flow_tag(9.99, precision: 2)
+
+      assert_includes html, 'aria-label="9.99"'
+      assert_includes html, 'data-digit="9"'
     end
   end
 end

--- a/test/number_flow/helper_test.rb
+++ b/test/number_flow/helper_test.rb
@@ -111,8 +111,11 @@ module NumberFlow
       html = build_view.number_flow_tag(1234)
 
       assert_includes html, 'data-number-flow-value-value="1234"'
-      assert_includes html, 'data-number-flow-precision-value="0"'
       assert_includes html, 'aria-label="1234"'
+      # precision: 0 (default) must NOT emit a precision data attribute
+      # so integer output is byte-identical to the original gem.
+      refute_includes html, 'data-number-flow-precision-value'
+      refute_includes html, 'data-number-flow-locale-value'
     end
 
     def test_locale_option_emits_data_attribute

--- a/test/system/animation_test.rb
+++ b/test/system/animation_test.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Gate system tests behind an env var so they don't run in environments
+# without Chrome (e.g., basic CI or local quick-test runs).
+if ENV['RUN_SYSTEM_TESTS'] == 'true'
+  require_relative 'test_support'
+  require 'capybara/minitest'
+
+  module NumberFlow
+    class AnimationSystemTest < Minitest::Test
+      include Capybara::DSL
+      include Capybara::Minitest::Assertions
+      include NumberFlow::SystemTestHelper
+
+      def teardown
+        Capybara.reset_sessions!
+      end
+
+      def setup_browser_page(html_content)
+        Capybara.current_driver = :number_flow_cuprite
+        Capybara.app = lambda do |_env|
+          [200, { 'content-type' => 'text/html' }, [html_content]]
+        end
+        visit '/'
+      end
+
+      def dispatch_update(value)
+        page.execute_script(<<~JS)
+          const el = document.querySelector('[data-controller="number-flow"]');
+          el.dispatchEvent(new CustomEvent("number-flow:update", { detail: { value: #{value} } }));
+        JS
+      end
+
+      def wait_for_stimulus_connect
+        # Wait for Stimulus to be loaded and controller to have connected
+        sleep 0.5
+      end
+
+      # Acceptance: A browser-backed test dispatches number-flow:update
+      # and verifies final rendered digits
+      def test_update_animates_to_final_digits
+        html = build_html_page(initial_html: build_number_flow_markup(0))
+        setup_browser_page(html)
+
+        page.assert_selector('[data-controller="number-flow"]', visible: true)
+        wait_for_stimulus_connect
+
+        # Verify initial state shows digit 0
+        initial_digits = page.all('.nf__digit[data-digit]')
+        assert_equal 1, initial_digits.length, 'Should start with one digit (0)'
+
+        # Dispatch update event to change value to 5
+        dispatch_update(5)
+
+        # Give the animation a moment to render
+        sleep 0.3
+
+        # Verify final rendered digits show 5
+        digits = page.all('.nf__digit[data-digit]')
+        assert_equal 1, digits.length
+        assert_equal '5', digits.first['data-digit']
+
+        # Verify the aria-label is updated
+        label = page.find('[data-controller="number-flow"]')[:'aria-label']
+        assert_equal '5', label
+      end
+
+      def test_update_to_multi_digit_value
+        html = build_html_page(initial_html: build_number_flow_markup(0))
+        setup_browser_page(html)
+
+        page.assert_selector('[data-controller="number-flow"]', visible: true)
+        wait_for_stimulus_connect
+
+        dispatch_update(123)
+
+        sleep 0.3
+
+        digits = page.all('.nf__digit[data-digit]')
+        assert_equal 3, digits.length
+        digit_values = digits.map { |d| d['data-digit'] }
+        assert_equal %w[1 2 3], digit_values
+
+        label = page.find('[data-controller="number-flow"]')[:'aria-label']
+        assert_equal '123', label
+      end
+
+      def test_decimal_update_and_final_digits
+        html = build_html_page(initial_html: build_number_flow_markup(0, precision: 2))
+        setup_browser_page(html)
+
+        page.assert_selector('[data-controller="number-flow"]', visible: true)
+        wait_for_stimulus_connect
+
+        dispatch_update(12.34)
+
+        sleep 0.3
+
+        digits = page.all('.nf__digit[data-digit]')
+        digit_values = digits.map { |d| d['data-digit'] }
+        assert_equal %w[1 2 3 4], digit_values, 'Should show digits 1,2,3,4 for 12.34'
+
+        separators = page.all('.nf__separator')
+        assert(separators.any? { |s| s.text == '.' }, 'Should have a decimal separator')
+
+        label = page.find('[data-controller="number-flow"]')[:'aria-label']
+        assert_equal '12.34', label
+      end
+
+      def test_rollover_from_nine_nine_nine
+        html = build_html_page(initial_html: build_number_flow_markup(9.99, precision: 2))
+        setup_browser_page(html)
+
+        page.assert_selector('[data-controller="number-flow"]', visible: true)
+        wait_for_stimulus_connect
+
+        dispatch_update(10.00)
+
+        sleep 0.3
+
+        digits = page.all('.nf__digit[data-digit]')
+        digit_values = digits.map { |d| d['data-digit'] }
+        assert_equal %w[1 0 0 0], digit_values, '9.99 -> 10.00 rollover'
+
+        label = page.find('[data-controller="number-flow"]')[:'aria-label']
+        assert_equal '10.00', label
+      end
+
+      # Acceptance: Reduced-motion scenario is covered
+      def test_reduced_motion_skips_animation_track_class
+        html = build_html_page(initial_html: build_number_flow_markup(0))
+        setup_browser_page(html)
+
+        page.assert_selector('[data-controller="number-flow"]', visible: true)
+        wait_for_stimulus_connect
+
+        # Override the reduced motion media query to return true (reduced)
+        page.execute_script(<<~JS)
+          const controller = window.StimulusApp.controllers.find(c =>
+            c.element.hasAttribute('data-controller') &&
+            c.element.getAttribute('data-controller').includes('number-flow')
+          );
+          if (controller) {
+            controller.reducedMotionMedia = { matches: true };
+          }
+        JS
+
+        dispatch_update(7)
+
+        sleep 0.2
+
+        # With reduced motion, the track should NOT have the animated class
+        animated_tracks = page.all('.nf__track--animated')
+        assert_equal 0, animated_tracks.length,
+                     'No animated tracks when prefers-reduced-motion: reduce'
+
+        # The final digit should still be correct
+        digits = page.all('.nf__digit[data-digit]')
+        assert_equal '7', digits.last['data-digit']
+      end
+
+      def test_negative_value_animation
+        html = build_html_page(initial_html: build_number_flow_markup(0))
+        setup_browser_page(html)
+
+        page.assert_selector('[data-controller="number-flow"]', visible: true)
+        wait_for_stimulus_connect
+
+        dispatch_update(-42)
+
+        sleep 0.3
+
+        digits = page.all('.nf__digit[data-digit]')
+        digit_values = digits.map { |d| d['data-digit'] }
+        assert_equal %w[4 2], digit_values
+
+        separators = page.all('.nf__separator')
+        assert(separators.any? { |s| s.text == '-' }, 'Should have a negative sign separator')
+
+        label = page.find('[data-controller="number-flow"]')[:'aria-label']
+        assert_equal '-42', label
+      end
+
+      def test_locale_de_de_formatting
+        html = build_html_page(
+          initial_html: build_number_flow_markup(1234.5, precision: 1, grouping: true, locale: 'de-DE')
+        )
+        setup_browser_page(html)
+
+        page.assert_selector('[data-controller="number-flow"]', visible: true)
+        wait_for_stimulus_connect
+
+        # After Stimulus connect, JS re-renders with Intl.NumberFormat
+        sleep 0.3
+
+        label = page.find('[data-controller="number-flow"]')[:'aria-label']
+        assert_equal '1.234,5', label, 'de-DE locale should format as 1.234,5'
+      end
+    end
+  end
+else
+  warn '[number_flow] Skipping system tests (set RUN_SYSTEM_TESTS=true to enable)'
+end

--- a/test/system/support/stimulus.js
+++ b/test/system/support/stimulus.js
@@ -1,0 +1,2588 @@
+/*
+Stimulus 3.2.1
+Copyright © 2023 Basecamp, LLC
+ */
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.Stimulus = {}));
+}(this, (function (exports) { 'use strict';
+
+    class EventListener {
+        constructor(eventTarget, eventName, eventOptions) {
+            this.eventTarget = eventTarget;
+            this.eventName = eventName;
+            this.eventOptions = eventOptions;
+            this.unorderedBindings = new Set();
+        }
+        connect() {
+            this.eventTarget.addEventListener(this.eventName, this, this.eventOptions);
+        }
+        disconnect() {
+            this.eventTarget.removeEventListener(this.eventName, this, this.eventOptions);
+        }
+        bindingConnected(binding) {
+            this.unorderedBindings.add(binding);
+        }
+        bindingDisconnected(binding) {
+            this.unorderedBindings.delete(binding);
+        }
+        handleEvent(event) {
+            const extendedEvent = extendEvent(event);
+            for (const binding of this.bindings) {
+                if (extendedEvent.immediatePropagationStopped) {
+                    break;
+                }
+                else {
+                    binding.handleEvent(extendedEvent);
+                }
+            }
+        }
+        hasBindings() {
+            return this.unorderedBindings.size > 0;
+        }
+        get bindings() {
+            return Array.from(this.unorderedBindings).sort((left, right) => {
+                const leftIndex = left.index, rightIndex = right.index;
+                return leftIndex < rightIndex ? -1 : leftIndex > rightIndex ? 1 : 0;
+            });
+        }
+    }
+    function extendEvent(event) {
+        if ("immediatePropagationStopped" in event) {
+            return event;
+        }
+        else {
+            const { stopImmediatePropagation } = event;
+            return Object.assign(event, {
+                immediatePropagationStopped: false,
+                stopImmediatePropagation() {
+                    this.immediatePropagationStopped = true;
+                    stopImmediatePropagation.call(this);
+                },
+            });
+        }
+    }
+
+    class Dispatcher {
+        constructor(application) {
+            this.application = application;
+            this.eventListenerMaps = new Map();
+            this.started = false;
+        }
+        start() {
+            if (!this.started) {
+                this.started = true;
+                this.eventListeners.forEach((eventListener) => eventListener.connect());
+            }
+        }
+        stop() {
+            if (this.started) {
+                this.started = false;
+                this.eventListeners.forEach((eventListener) => eventListener.disconnect());
+            }
+        }
+        get eventListeners() {
+            return Array.from(this.eventListenerMaps.values()).reduce((listeners, map) => listeners.concat(Array.from(map.values())), []);
+        }
+        bindingConnected(binding) {
+            this.fetchEventListenerForBinding(binding).bindingConnected(binding);
+        }
+        bindingDisconnected(binding, clearEventListeners = false) {
+            this.fetchEventListenerForBinding(binding).bindingDisconnected(binding);
+            if (clearEventListeners)
+                this.clearEventListenersForBinding(binding);
+        }
+        handleError(error, message, detail = {}) {
+            this.application.handleError(error, `Error ${message}`, detail);
+        }
+        clearEventListenersForBinding(binding) {
+            const eventListener = this.fetchEventListenerForBinding(binding);
+            if (!eventListener.hasBindings()) {
+                eventListener.disconnect();
+                this.removeMappedEventListenerFor(binding);
+            }
+        }
+        removeMappedEventListenerFor(binding) {
+            const { eventTarget, eventName, eventOptions } = binding;
+            const eventListenerMap = this.fetchEventListenerMapForEventTarget(eventTarget);
+            const cacheKey = this.cacheKey(eventName, eventOptions);
+            eventListenerMap.delete(cacheKey);
+            if (eventListenerMap.size == 0)
+                this.eventListenerMaps.delete(eventTarget);
+        }
+        fetchEventListenerForBinding(binding) {
+            const { eventTarget, eventName, eventOptions } = binding;
+            return this.fetchEventListener(eventTarget, eventName, eventOptions);
+        }
+        fetchEventListener(eventTarget, eventName, eventOptions) {
+            const eventListenerMap = this.fetchEventListenerMapForEventTarget(eventTarget);
+            const cacheKey = this.cacheKey(eventName, eventOptions);
+            let eventListener = eventListenerMap.get(cacheKey);
+            if (!eventListener) {
+                eventListener = this.createEventListener(eventTarget, eventName, eventOptions);
+                eventListenerMap.set(cacheKey, eventListener);
+            }
+            return eventListener;
+        }
+        createEventListener(eventTarget, eventName, eventOptions) {
+            const eventListener = new EventListener(eventTarget, eventName, eventOptions);
+            if (this.started) {
+                eventListener.connect();
+            }
+            return eventListener;
+        }
+        fetchEventListenerMapForEventTarget(eventTarget) {
+            let eventListenerMap = this.eventListenerMaps.get(eventTarget);
+            if (!eventListenerMap) {
+                eventListenerMap = new Map();
+                this.eventListenerMaps.set(eventTarget, eventListenerMap);
+            }
+            return eventListenerMap;
+        }
+        cacheKey(eventName, eventOptions) {
+            const parts = [eventName];
+            Object.keys(eventOptions)
+                .sort()
+                .forEach((key) => {
+                parts.push(`${eventOptions[key] ? "" : "!"}${key}`);
+            });
+            return parts.join(":");
+        }
+    }
+
+    const defaultActionDescriptorFilters = {
+        stop({ event, value }) {
+            if (value)
+                event.stopPropagation();
+            return true;
+        },
+        prevent({ event, value }) {
+            if (value)
+                event.preventDefault();
+            return true;
+        },
+        self({ event, value, element }) {
+            if (value) {
+                return element === event.target;
+            }
+            else {
+                return true;
+            }
+        },
+    };
+    const descriptorPattern = /^(?:(?:([^.]+?)\+)?(.+?)(?:\.(.+?))?(?:@(window|document))?->)?(.+?)(?:#([^:]+?))(?::(.+))?$/;
+    function parseActionDescriptorString(descriptorString) {
+        const source = descriptorString.trim();
+        const matches = source.match(descriptorPattern) || [];
+        let eventName = matches[2];
+        let keyFilter = matches[3];
+        if (keyFilter && !["keydown", "keyup", "keypress"].includes(eventName)) {
+            eventName += `.${keyFilter}`;
+            keyFilter = "";
+        }
+        return {
+            eventTarget: parseEventTarget(matches[4]),
+            eventName,
+            eventOptions: matches[7] ? parseEventOptions(matches[7]) : {},
+            identifier: matches[5],
+            methodName: matches[6],
+            keyFilter: matches[1] || keyFilter,
+        };
+    }
+    function parseEventTarget(eventTargetName) {
+        if (eventTargetName == "window") {
+            return window;
+        }
+        else if (eventTargetName == "document") {
+            return document;
+        }
+    }
+    function parseEventOptions(eventOptions) {
+        return eventOptions
+            .split(":")
+            .reduce((options, token) => Object.assign(options, { [token.replace(/^!/, "")]: !/^!/.test(token) }), {});
+    }
+    function stringifyEventTarget(eventTarget) {
+        if (eventTarget == window) {
+            return "window";
+        }
+        else if (eventTarget == document) {
+            return "document";
+        }
+    }
+
+    function camelize(value) {
+        return value.replace(/(?:[_-])([a-z0-9])/g, (_, char) => char.toUpperCase());
+    }
+    function namespaceCamelize(value) {
+        return camelize(value.replace(/--/g, "-").replace(/__/g, "_"));
+    }
+    function capitalize(value) {
+        return value.charAt(0).toUpperCase() + value.slice(1);
+    }
+    function dasherize(value) {
+        return value.replace(/([A-Z])/g, (_, char) => `-${char.toLowerCase()}`);
+    }
+    function tokenize(value) {
+        return value.match(/[^\s]+/g) || [];
+    }
+
+    function isSomething(object) {
+        return object !== null && object !== undefined;
+    }
+    function hasProperty(object, property) {
+        return Object.prototype.hasOwnProperty.call(object, property);
+    }
+
+    const allModifiers = ["meta", "ctrl", "alt", "shift"];
+    class Action {
+        constructor(element, index, descriptor, schema) {
+            this.element = element;
+            this.index = index;
+            this.eventTarget = descriptor.eventTarget || element;
+            this.eventName = descriptor.eventName || getDefaultEventNameForElement(element) || error("missing event name");
+            this.eventOptions = descriptor.eventOptions || {};
+            this.identifier = descriptor.identifier || error("missing identifier");
+            this.methodName = descriptor.methodName || error("missing method name");
+            this.keyFilter = descriptor.keyFilter || "";
+            this.schema = schema;
+        }
+        static forToken(token, schema) {
+            return new this(token.element, token.index, parseActionDescriptorString(token.content), schema);
+        }
+        toString() {
+            const eventFilter = this.keyFilter ? `.${this.keyFilter}` : "";
+            const eventTarget = this.eventTargetName ? `@${this.eventTargetName}` : "";
+            return `${this.eventName}${eventFilter}${eventTarget}->${this.identifier}#${this.methodName}`;
+        }
+        shouldIgnoreKeyboardEvent(event) {
+            if (!this.keyFilter) {
+                return false;
+            }
+            const filters = this.keyFilter.split("+");
+            if (this.keyFilterDissatisfied(event, filters)) {
+                return true;
+            }
+            const standardFilter = filters.filter((key) => !allModifiers.includes(key))[0];
+            if (!standardFilter) {
+                return false;
+            }
+            if (!hasProperty(this.keyMappings, standardFilter)) {
+                error(`contains unknown key filter: ${this.keyFilter}`);
+            }
+            return this.keyMappings[standardFilter].toLowerCase() !== event.key.toLowerCase();
+        }
+        shouldIgnoreMouseEvent(event) {
+            if (!this.keyFilter) {
+                return false;
+            }
+            const filters = [this.keyFilter];
+            if (this.keyFilterDissatisfied(event, filters)) {
+                return true;
+            }
+            return false;
+        }
+        get params() {
+            const params = {};
+            const pattern = new RegExp(`^data-${this.identifier}-(.+)-param$`, "i");
+            for (const { name, value } of Array.from(this.element.attributes)) {
+                const match = name.match(pattern);
+                const key = match && match[1];
+                if (key) {
+                    params[camelize(key)] = typecast(value);
+                }
+            }
+            return params;
+        }
+        get eventTargetName() {
+            return stringifyEventTarget(this.eventTarget);
+        }
+        get keyMappings() {
+            return this.schema.keyMappings;
+        }
+        keyFilterDissatisfied(event, filters) {
+            const [meta, ctrl, alt, shift] = allModifiers.map((modifier) => filters.includes(modifier));
+            return event.metaKey !== meta || event.ctrlKey !== ctrl || event.altKey !== alt || event.shiftKey !== shift;
+        }
+    }
+    const defaultEventNames = {
+        a: () => "click",
+        button: () => "click",
+        form: () => "submit",
+        details: () => "toggle",
+        input: (e) => (e.getAttribute("type") == "submit" ? "click" : "input"),
+        select: () => "change",
+        textarea: () => "input",
+    };
+    function getDefaultEventNameForElement(element) {
+        const tagName = element.tagName.toLowerCase();
+        if (tagName in defaultEventNames) {
+            return defaultEventNames[tagName](element);
+        }
+    }
+    function error(message) {
+        throw new Error(message);
+    }
+    function typecast(value) {
+        try {
+            return JSON.parse(value);
+        }
+        catch (o_O) {
+            return value;
+        }
+    }
+
+    class Binding {
+        constructor(context, action) {
+            this.context = context;
+            this.action = action;
+        }
+        get index() {
+            return this.action.index;
+        }
+        get eventTarget() {
+            return this.action.eventTarget;
+        }
+        get eventOptions() {
+            return this.action.eventOptions;
+        }
+        get identifier() {
+            return this.context.identifier;
+        }
+        handleEvent(event) {
+            const actionEvent = this.prepareActionEvent(event);
+            if (this.willBeInvokedByEvent(event) && this.applyEventModifiers(actionEvent)) {
+                this.invokeWithEvent(actionEvent);
+            }
+        }
+        get eventName() {
+            return this.action.eventName;
+        }
+        get method() {
+            const method = this.controller[this.methodName];
+            if (typeof method == "function") {
+                return method;
+            }
+            throw new Error(`Action "${this.action}" references undefined method "${this.methodName}"`);
+        }
+        applyEventModifiers(event) {
+            const { element } = this.action;
+            const { actionDescriptorFilters } = this.context.application;
+            const { controller } = this.context;
+            let passes = true;
+            for (const [name, value] of Object.entries(this.eventOptions)) {
+                if (name in actionDescriptorFilters) {
+                    const filter = actionDescriptorFilters[name];
+                    passes = passes && filter({ name, value, event, element, controller });
+                }
+                else {
+                    continue;
+                }
+            }
+            return passes;
+        }
+        prepareActionEvent(event) {
+            return Object.assign(event, { params: this.action.params });
+        }
+        invokeWithEvent(event) {
+            const { target, currentTarget } = event;
+            try {
+                this.method.call(this.controller, event);
+                this.context.logDebugActivity(this.methodName, { event, target, currentTarget, action: this.methodName });
+            }
+            catch (error) {
+                const { identifier, controller, element, index } = this;
+                const detail = { identifier, controller, element, index, event };
+                this.context.handleError(error, `invoking action "${this.action}"`, detail);
+            }
+        }
+        willBeInvokedByEvent(event) {
+            const eventTarget = event.target;
+            if (event instanceof KeyboardEvent && this.action.shouldIgnoreKeyboardEvent(event)) {
+                return false;
+            }
+            if (event instanceof MouseEvent && this.action.shouldIgnoreMouseEvent(event)) {
+                return false;
+            }
+            if (this.element === eventTarget) {
+                return true;
+            }
+            else if (eventTarget instanceof Element && this.element.contains(eventTarget)) {
+                return this.scope.containsElement(eventTarget);
+            }
+            else {
+                return this.scope.containsElement(this.action.element);
+            }
+        }
+        get controller() {
+            return this.context.controller;
+        }
+        get methodName() {
+            return this.action.methodName;
+        }
+        get element() {
+            return this.scope.element;
+        }
+        get scope() {
+            return this.context.scope;
+        }
+    }
+
+    class ElementObserver {
+        constructor(element, delegate) {
+            this.mutationObserverInit = { attributes: true, childList: true, subtree: true };
+            this.element = element;
+            this.started = false;
+            this.delegate = delegate;
+            this.elements = new Set();
+            this.mutationObserver = new MutationObserver((mutations) => this.processMutations(mutations));
+        }
+        start() {
+            if (!this.started) {
+                this.started = true;
+                this.mutationObserver.observe(this.element, this.mutationObserverInit);
+                this.refresh();
+            }
+        }
+        pause(callback) {
+            if (this.started) {
+                this.mutationObserver.disconnect();
+                this.started = false;
+            }
+            callback();
+            if (!this.started) {
+                this.mutationObserver.observe(this.element, this.mutationObserverInit);
+                this.started = true;
+            }
+        }
+        stop() {
+            if (this.started) {
+                this.mutationObserver.takeRecords();
+                this.mutationObserver.disconnect();
+                this.started = false;
+            }
+        }
+        refresh() {
+            if (this.started) {
+                const matches = new Set(this.matchElementsInTree());
+                for (const element of Array.from(this.elements)) {
+                    if (!matches.has(element)) {
+                        this.removeElement(element);
+                    }
+                }
+                for (const element of Array.from(matches)) {
+                    this.addElement(element);
+                }
+            }
+        }
+        processMutations(mutations) {
+            if (this.started) {
+                for (const mutation of mutations) {
+                    this.processMutation(mutation);
+                }
+            }
+        }
+        processMutation(mutation) {
+            if (mutation.type == "attributes") {
+                this.processAttributeChange(mutation.target, mutation.attributeName);
+            }
+            else if (mutation.type == "childList") {
+                this.processRemovedNodes(mutation.removedNodes);
+                this.processAddedNodes(mutation.addedNodes);
+            }
+        }
+        processAttributeChange(element, attributeName) {
+            if (this.elements.has(element)) {
+                if (this.delegate.elementAttributeChanged && this.matchElement(element)) {
+                    this.delegate.elementAttributeChanged(element, attributeName);
+                }
+                else {
+                    this.removeElement(element);
+                }
+            }
+            else if (this.matchElement(element)) {
+                this.addElement(element);
+            }
+        }
+        processRemovedNodes(nodes) {
+            for (const node of Array.from(nodes)) {
+                const element = this.elementFromNode(node);
+                if (element) {
+                    this.processTree(element, this.removeElement);
+                }
+            }
+        }
+        processAddedNodes(nodes) {
+            for (const node of Array.from(nodes)) {
+                const element = this.elementFromNode(node);
+                if (element && this.elementIsActive(element)) {
+                    this.processTree(element, this.addElement);
+                }
+            }
+        }
+        matchElement(element) {
+            return this.delegate.matchElement(element);
+        }
+        matchElementsInTree(tree = this.element) {
+            return this.delegate.matchElementsInTree(tree);
+        }
+        processTree(tree, processor) {
+            for (const element of this.matchElementsInTree(tree)) {
+                processor.call(this, element);
+            }
+        }
+        elementFromNode(node) {
+            if (node.nodeType == Node.ELEMENT_NODE) {
+                return node;
+            }
+        }
+        elementIsActive(element) {
+            if (element.isConnected != this.element.isConnected) {
+                return false;
+            }
+            else {
+                return this.element.contains(element);
+            }
+        }
+        addElement(element) {
+            if (!this.elements.has(element)) {
+                if (this.elementIsActive(element)) {
+                    this.elements.add(element);
+                    if (this.delegate.elementMatched) {
+                        this.delegate.elementMatched(element);
+                    }
+                }
+            }
+        }
+        removeElement(element) {
+            if (this.elements.has(element)) {
+                this.elements.delete(element);
+                if (this.delegate.elementUnmatched) {
+                    this.delegate.elementUnmatched(element);
+                }
+            }
+        }
+    }
+
+    class AttributeObserver {
+        constructor(element, attributeName, delegate) {
+            this.attributeName = attributeName;
+            this.delegate = delegate;
+            this.elementObserver = new ElementObserver(element, this);
+        }
+        get element() {
+            return this.elementObserver.element;
+        }
+        get selector() {
+            return `[${this.attributeName}]`;
+        }
+        start() {
+            this.elementObserver.start();
+        }
+        pause(callback) {
+            this.elementObserver.pause(callback);
+        }
+        stop() {
+            this.elementObserver.stop();
+        }
+        refresh() {
+            this.elementObserver.refresh();
+        }
+        get started() {
+            return this.elementObserver.started;
+        }
+        matchElement(element) {
+            return element.hasAttribute(this.attributeName);
+        }
+        matchElementsInTree(tree) {
+            const match = this.matchElement(tree) ? [tree] : [];
+            const matches = Array.from(tree.querySelectorAll(this.selector));
+            return match.concat(matches);
+        }
+        elementMatched(element) {
+            if (this.delegate.elementMatchedAttribute) {
+                this.delegate.elementMatchedAttribute(element, this.attributeName);
+            }
+        }
+        elementUnmatched(element) {
+            if (this.delegate.elementUnmatchedAttribute) {
+                this.delegate.elementUnmatchedAttribute(element, this.attributeName);
+            }
+        }
+        elementAttributeChanged(element, attributeName) {
+            if (this.delegate.elementAttributeValueChanged && this.attributeName == attributeName) {
+                this.delegate.elementAttributeValueChanged(element, attributeName);
+            }
+        }
+    }
+
+    function add(map, key, value) {
+        fetch(map, key).add(value);
+    }
+    function del(map, key, value) {
+        fetch(map, key).delete(value);
+        prune(map, key);
+    }
+    function fetch(map, key) {
+        let values = map.get(key);
+        if (!values) {
+            values = new Set();
+            map.set(key, values);
+        }
+        return values;
+    }
+    function prune(map, key) {
+        const values = map.get(key);
+        if (values != null && values.size == 0) {
+            map.delete(key);
+        }
+    }
+
+    class Multimap {
+        constructor() {
+            this.valuesByKey = new Map();
+        }
+        get keys() {
+            return Array.from(this.valuesByKey.keys());
+        }
+        get values() {
+            const sets = Array.from(this.valuesByKey.values());
+            return sets.reduce((values, set) => values.concat(Array.from(set)), []);
+        }
+        get size() {
+            const sets = Array.from(this.valuesByKey.values());
+            return sets.reduce((size, set) => size + set.size, 0);
+        }
+        add(key, value) {
+            add(this.valuesByKey, key, value);
+        }
+        delete(key, value) {
+            del(this.valuesByKey, key, value);
+        }
+        has(key, value) {
+            const values = this.valuesByKey.get(key);
+            return values != null && values.has(value);
+        }
+        hasKey(key) {
+            return this.valuesByKey.has(key);
+        }
+        hasValue(value) {
+            const sets = Array.from(this.valuesByKey.values());
+            return sets.some((set) => set.has(value));
+        }
+        getValuesForKey(key) {
+            const values = this.valuesByKey.get(key);
+            return values ? Array.from(values) : [];
+        }
+        getKeysForValue(value) {
+            return Array.from(this.valuesByKey)
+                .filter(([_key, values]) => values.has(value))
+                .map(([key, _values]) => key);
+        }
+    }
+
+    class IndexedMultimap extends Multimap {
+        constructor() {
+            super();
+            this.keysByValue = new Map();
+        }
+        get values() {
+            return Array.from(this.keysByValue.keys());
+        }
+        add(key, value) {
+            super.add(key, value);
+            add(this.keysByValue, value, key);
+        }
+        delete(key, value) {
+            super.delete(key, value);
+            del(this.keysByValue, value, key);
+        }
+        hasValue(value) {
+            return this.keysByValue.has(value);
+        }
+        getKeysForValue(value) {
+            const set = this.keysByValue.get(value);
+            return set ? Array.from(set) : [];
+        }
+    }
+
+    class SelectorObserver {
+        constructor(element, selector, delegate, details) {
+            this._selector = selector;
+            this.details = details;
+            this.elementObserver = new ElementObserver(element, this);
+            this.delegate = delegate;
+            this.matchesByElement = new Multimap();
+        }
+        get started() {
+            return this.elementObserver.started;
+        }
+        get selector() {
+            return this._selector;
+        }
+        set selector(selector) {
+            this._selector = selector;
+            this.refresh();
+        }
+        start() {
+            this.elementObserver.start();
+        }
+        pause(callback) {
+            this.elementObserver.pause(callback);
+        }
+        stop() {
+            this.elementObserver.stop();
+        }
+        refresh() {
+            this.elementObserver.refresh();
+        }
+        get element() {
+            return this.elementObserver.element;
+        }
+        matchElement(element) {
+            const { selector } = this;
+            if (selector) {
+                const matches = element.matches(selector);
+                if (this.delegate.selectorMatchElement) {
+                    return matches && this.delegate.selectorMatchElement(element, this.details);
+                }
+                return matches;
+            }
+            else {
+                return false;
+            }
+        }
+        matchElementsInTree(tree) {
+            const { selector } = this;
+            if (selector) {
+                const match = this.matchElement(tree) ? [tree] : [];
+                const matches = Array.from(tree.querySelectorAll(selector)).filter((match) => this.matchElement(match));
+                return match.concat(matches);
+            }
+            else {
+                return [];
+            }
+        }
+        elementMatched(element) {
+            const { selector } = this;
+            if (selector) {
+                this.selectorMatched(element, selector);
+            }
+        }
+        elementUnmatched(element) {
+            const selectors = this.matchesByElement.getKeysForValue(element);
+            for (const selector of selectors) {
+                this.selectorUnmatched(element, selector);
+            }
+        }
+        elementAttributeChanged(element, _attributeName) {
+            const { selector } = this;
+            if (selector) {
+                const matches = this.matchElement(element);
+                const matchedBefore = this.matchesByElement.has(selector, element);
+                if (matches && !matchedBefore) {
+                    this.selectorMatched(element, selector);
+                }
+                else if (!matches && matchedBefore) {
+                    this.selectorUnmatched(element, selector);
+                }
+            }
+        }
+        selectorMatched(element, selector) {
+            this.delegate.selectorMatched(element, selector, this.details);
+            this.matchesByElement.add(selector, element);
+        }
+        selectorUnmatched(element, selector) {
+            this.delegate.selectorUnmatched(element, selector, this.details);
+            this.matchesByElement.delete(selector, element);
+        }
+    }
+
+    class StringMapObserver {
+        constructor(element, delegate) {
+            this.element = element;
+            this.delegate = delegate;
+            this.started = false;
+            this.stringMap = new Map();
+            this.mutationObserver = new MutationObserver((mutations) => this.processMutations(mutations));
+        }
+        start() {
+            if (!this.started) {
+                this.started = true;
+                this.mutationObserver.observe(this.element, { attributes: true, attributeOldValue: true });
+                this.refresh();
+            }
+        }
+        stop() {
+            if (this.started) {
+                this.mutationObserver.takeRecords();
+                this.mutationObserver.disconnect();
+                this.started = false;
+            }
+        }
+        refresh() {
+            if (this.started) {
+                for (const attributeName of this.knownAttributeNames) {
+                    this.refreshAttribute(attributeName, null);
+                }
+            }
+        }
+        processMutations(mutations) {
+            if (this.started) {
+                for (const mutation of mutations) {
+                    this.processMutation(mutation);
+                }
+            }
+        }
+        processMutation(mutation) {
+            const attributeName = mutation.attributeName;
+            if (attributeName) {
+                this.refreshAttribute(attributeName, mutation.oldValue);
+            }
+        }
+        refreshAttribute(attributeName, oldValue) {
+            const key = this.delegate.getStringMapKeyForAttribute(attributeName);
+            if (key != null) {
+                if (!this.stringMap.has(attributeName)) {
+                    this.stringMapKeyAdded(key, attributeName);
+                }
+                const value = this.element.getAttribute(attributeName);
+                if (this.stringMap.get(attributeName) != value) {
+                    this.stringMapValueChanged(value, key, oldValue);
+                }
+                if (value == null) {
+                    const oldValue = this.stringMap.get(attributeName);
+                    this.stringMap.delete(attributeName);
+                    if (oldValue)
+                        this.stringMapKeyRemoved(key, attributeName, oldValue);
+                }
+                else {
+                    this.stringMap.set(attributeName, value);
+                }
+            }
+        }
+        stringMapKeyAdded(key, attributeName) {
+            if (this.delegate.stringMapKeyAdded) {
+                this.delegate.stringMapKeyAdded(key, attributeName);
+            }
+        }
+        stringMapValueChanged(value, key, oldValue) {
+            if (this.delegate.stringMapValueChanged) {
+                this.delegate.stringMapValueChanged(value, key, oldValue);
+            }
+        }
+        stringMapKeyRemoved(key, attributeName, oldValue) {
+            if (this.delegate.stringMapKeyRemoved) {
+                this.delegate.stringMapKeyRemoved(key, attributeName, oldValue);
+            }
+        }
+        get knownAttributeNames() {
+            return Array.from(new Set(this.currentAttributeNames.concat(this.recordedAttributeNames)));
+        }
+        get currentAttributeNames() {
+            return Array.from(this.element.attributes).map((attribute) => attribute.name);
+        }
+        get recordedAttributeNames() {
+            return Array.from(this.stringMap.keys());
+        }
+    }
+
+    class TokenListObserver {
+        constructor(element, attributeName, delegate) {
+            this.attributeObserver = new AttributeObserver(element, attributeName, this);
+            this.delegate = delegate;
+            this.tokensByElement = new Multimap();
+        }
+        get started() {
+            return this.attributeObserver.started;
+        }
+        start() {
+            this.attributeObserver.start();
+        }
+        pause(callback) {
+            this.attributeObserver.pause(callback);
+        }
+        stop() {
+            this.attributeObserver.stop();
+        }
+        refresh() {
+            this.attributeObserver.refresh();
+        }
+        get element() {
+            return this.attributeObserver.element;
+        }
+        get attributeName() {
+            return this.attributeObserver.attributeName;
+        }
+        elementMatchedAttribute(element) {
+            this.tokensMatched(this.readTokensForElement(element));
+        }
+        elementAttributeValueChanged(element) {
+            const [unmatchedTokens, matchedTokens] = this.refreshTokensForElement(element);
+            this.tokensUnmatched(unmatchedTokens);
+            this.tokensMatched(matchedTokens);
+        }
+        elementUnmatchedAttribute(element) {
+            this.tokensUnmatched(this.tokensByElement.getValuesForKey(element));
+        }
+        tokensMatched(tokens) {
+            tokens.forEach((token) => this.tokenMatched(token));
+        }
+        tokensUnmatched(tokens) {
+            tokens.forEach((token) => this.tokenUnmatched(token));
+        }
+        tokenMatched(token) {
+            this.delegate.tokenMatched(token);
+            this.tokensByElement.add(token.element, token);
+        }
+        tokenUnmatched(token) {
+            this.delegate.tokenUnmatched(token);
+            this.tokensByElement.delete(token.element, token);
+        }
+        refreshTokensForElement(element) {
+            const previousTokens = this.tokensByElement.getValuesForKey(element);
+            const currentTokens = this.readTokensForElement(element);
+            const firstDifferingIndex = zip(previousTokens, currentTokens).findIndex(([previousToken, currentToken]) => !tokensAreEqual(previousToken, currentToken));
+            if (firstDifferingIndex == -1) {
+                return [[], []];
+            }
+            else {
+                return [previousTokens.slice(firstDifferingIndex), currentTokens.slice(firstDifferingIndex)];
+            }
+        }
+        readTokensForElement(element) {
+            const attributeName = this.attributeName;
+            const tokenString = element.getAttribute(attributeName) || "";
+            return parseTokenString(tokenString, element, attributeName);
+        }
+    }
+    function parseTokenString(tokenString, element, attributeName) {
+        return tokenString
+            .trim()
+            .split(/\s+/)
+            .filter((content) => content.length)
+            .map((content, index) => ({ element, attributeName, content, index }));
+    }
+    function zip(left, right) {
+        const length = Math.max(left.length, right.length);
+        return Array.from({ length }, (_, index) => [left[index], right[index]]);
+    }
+    function tokensAreEqual(left, right) {
+        return left && right && left.index == right.index && left.content == right.content;
+    }
+
+    class ValueListObserver {
+        constructor(element, attributeName, delegate) {
+            this.tokenListObserver = new TokenListObserver(element, attributeName, this);
+            this.delegate = delegate;
+            this.parseResultsByToken = new WeakMap();
+            this.valuesByTokenByElement = new WeakMap();
+        }
+        get started() {
+            return this.tokenListObserver.started;
+        }
+        start() {
+            this.tokenListObserver.start();
+        }
+        stop() {
+            this.tokenListObserver.stop();
+        }
+        refresh() {
+            this.tokenListObserver.refresh();
+        }
+        get element() {
+            return this.tokenListObserver.element;
+        }
+        get attributeName() {
+            return this.tokenListObserver.attributeName;
+        }
+        tokenMatched(token) {
+            const { element } = token;
+            const { value } = this.fetchParseResultForToken(token);
+            if (value) {
+                this.fetchValuesByTokenForElement(element).set(token, value);
+                this.delegate.elementMatchedValue(element, value);
+            }
+        }
+        tokenUnmatched(token) {
+            const { element } = token;
+            const { value } = this.fetchParseResultForToken(token);
+            if (value) {
+                this.fetchValuesByTokenForElement(element).delete(token);
+                this.delegate.elementUnmatchedValue(element, value);
+            }
+        }
+        fetchParseResultForToken(token) {
+            let parseResult = this.parseResultsByToken.get(token);
+            if (!parseResult) {
+                parseResult = this.parseToken(token);
+                this.parseResultsByToken.set(token, parseResult);
+            }
+            return parseResult;
+        }
+        fetchValuesByTokenForElement(element) {
+            let valuesByToken = this.valuesByTokenByElement.get(element);
+            if (!valuesByToken) {
+                valuesByToken = new Map();
+                this.valuesByTokenByElement.set(element, valuesByToken);
+            }
+            return valuesByToken;
+        }
+        parseToken(token) {
+            try {
+                const value = this.delegate.parseValueForToken(token);
+                return { value };
+            }
+            catch (error) {
+                return { error };
+            }
+        }
+    }
+
+    class BindingObserver {
+        constructor(context, delegate) {
+            this.context = context;
+            this.delegate = delegate;
+            this.bindingsByAction = new Map();
+        }
+        start() {
+            if (!this.valueListObserver) {
+                this.valueListObserver = new ValueListObserver(this.element, this.actionAttribute, this);
+                this.valueListObserver.start();
+            }
+        }
+        stop() {
+            if (this.valueListObserver) {
+                this.valueListObserver.stop();
+                delete this.valueListObserver;
+                this.disconnectAllActions();
+            }
+        }
+        get element() {
+            return this.context.element;
+        }
+        get identifier() {
+            return this.context.identifier;
+        }
+        get actionAttribute() {
+            return this.schema.actionAttribute;
+        }
+        get schema() {
+            return this.context.schema;
+        }
+        get bindings() {
+            return Array.from(this.bindingsByAction.values());
+        }
+        connectAction(action) {
+            const binding = new Binding(this.context, action);
+            this.bindingsByAction.set(action, binding);
+            this.delegate.bindingConnected(binding);
+        }
+        disconnectAction(action) {
+            const binding = this.bindingsByAction.get(action);
+            if (binding) {
+                this.bindingsByAction.delete(action);
+                this.delegate.bindingDisconnected(binding);
+            }
+        }
+        disconnectAllActions() {
+            this.bindings.forEach((binding) => this.delegate.bindingDisconnected(binding, true));
+            this.bindingsByAction.clear();
+        }
+        parseValueForToken(token) {
+            const action = Action.forToken(token, this.schema);
+            if (action.identifier == this.identifier) {
+                return action;
+            }
+        }
+        elementMatchedValue(element, action) {
+            this.connectAction(action);
+        }
+        elementUnmatchedValue(element, action) {
+            this.disconnectAction(action);
+        }
+    }
+
+    class ValueObserver {
+        constructor(context, receiver) {
+            this.context = context;
+            this.receiver = receiver;
+            this.stringMapObserver = new StringMapObserver(this.element, this);
+            this.valueDescriptorMap = this.controller.valueDescriptorMap;
+        }
+        start() {
+            this.stringMapObserver.start();
+            this.invokeChangedCallbacksForDefaultValues();
+        }
+        stop() {
+            this.stringMapObserver.stop();
+        }
+        get element() {
+            return this.context.element;
+        }
+        get controller() {
+            return this.context.controller;
+        }
+        getStringMapKeyForAttribute(attributeName) {
+            if (attributeName in this.valueDescriptorMap) {
+                return this.valueDescriptorMap[attributeName].name;
+            }
+        }
+        stringMapKeyAdded(key, attributeName) {
+            const descriptor = this.valueDescriptorMap[attributeName];
+            if (!this.hasValue(key)) {
+                this.invokeChangedCallback(key, descriptor.writer(this.receiver[key]), descriptor.writer(descriptor.defaultValue));
+            }
+        }
+        stringMapValueChanged(value, name, oldValue) {
+            const descriptor = this.valueDescriptorNameMap[name];
+            if (value === null)
+                return;
+            if (oldValue === null) {
+                oldValue = descriptor.writer(descriptor.defaultValue);
+            }
+            this.invokeChangedCallback(name, value, oldValue);
+        }
+        stringMapKeyRemoved(key, attributeName, oldValue) {
+            const descriptor = this.valueDescriptorNameMap[key];
+            if (this.hasValue(key)) {
+                this.invokeChangedCallback(key, descriptor.writer(this.receiver[key]), oldValue);
+            }
+            else {
+                this.invokeChangedCallback(key, descriptor.writer(descriptor.defaultValue), oldValue);
+            }
+        }
+        invokeChangedCallbacksForDefaultValues() {
+            for (const { key, name, defaultValue, writer } of this.valueDescriptors) {
+                if (defaultValue != undefined && !this.controller.data.has(key)) {
+                    this.invokeChangedCallback(name, writer(defaultValue), undefined);
+                }
+            }
+        }
+        invokeChangedCallback(name, rawValue, rawOldValue) {
+            const changedMethodName = `${name}Changed`;
+            const changedMethod = this.receiver[changedMethodName];
+            if (typeof changedMethod == "function") {
+                const descriptor = this.valueDescriptorNameMap[name];
+                try {
+                    const value = descriptor.reader(rawValue);
+                    let oldValue = rawOldValue;
+                    if (rawOldValue) {
+                        oldValue = descriptor.reader(rawOldValue);
+                    }
+                    changedMethod.call(this.receiver, value, oldValue);
+                }
+                catch (error) {
+                    if (error instanceof TypeError) {
+                        error.message = `Stimulus Value "${this.context.identifier}.${descriptor.name}" - ${error.message}`;
+                    }
+                    throw error;
+                }
+            }
+        }
+        get valueDescriptors() {
+            const { valueDescriptorMap } = this;
+            return Object.keys(valueDescriptorMap).map((key) => valueDescriptorMap[key]);
+        }
+        get valueDescriptorNameMap() {
+            const descriptors = {};
+            Object.keys(this.valueDescriptorMap).forEach((key) => {
+                const descriptor = this.valueDescriptorMap[key];
+                descriptors[descriptor.name] = descriptor;
+            });
+            return descriptors;
+        }
+        hasValue(attributeName) {
+            const descriptor = this.valueDescriptorNameMap[attributeName];
+            const hasMethodName = `has${capitalize(descriptor.name)}`;
+            return this.receiver[hasMethodName];
+        }
+    }
+
+    class TargetObserver {
+        constructor(context, delegate) {
+            this.context = context;
+            this.delegate = delegate;
+            this.targetsByName = new Multimap();
+        }
+        start() {
+            if (!this.tokenListObserver) {
+                this.tokenListObserver = new TokenListObserver(this.element, this.attributeName, this);
+                this.tokenListObserver.start();
+            }
+        }
+        stop() {
+            if (this.tokenListObserver) {
+                this.disconnectAllTargets();
+                this.tokenListObserver.stop();
+                delete this.tokenListObserver;
+            }
+        }
+        tokenMatched({ element, content: name }) {
+            if (this.scope.containsElement(element)) {
+                this.connectTarget(element, name);
+            }
+        }
+        tokenUnmatched({ element, content: name }) {
+            this.disconnectTarget(element, name);
+        }
+        connectTarget(element, name) {
+            var _a;
+            if (!this.targetsByName.has(name, element)) {
+                this.targetsByName.add(name, element);
+                (_a = this.tokenListObserver) === null || _a === void 0 ? void 0 : _a.pause(() => this.delegate.targetConnected(element, name));
+            }
+        }
+        disconnectTarget(element, name) {
+            var _a;
+            if (this.targetsByName.has(name, element)) {
+                this.targetsByName.delete(name, element);
+                (_a = this.tokenListObserver) === null || _a === void 0 ? void 0 : _a.pause(() => this.delegate.targetDisconnected(element, name));
+            }
+        }
+        disconnectAllTargets() {
+            for (const name of this.targetsByName.keys) {
+                for (const element of this.targetsByName.getValuesForKey(name)) {
+                    this.disconnectTarget(element, name);
+                }
+            }
+        }
+        get attributeName() {
+            return `data-${this.context.identifier}-target`;
+        }
+        get element() {
+            return this.context.element;
+        }
+        get scope() {
+            return this.context.scope;
+        }
+    }
+
+    function readInheritableStaticArrayValues(constructor, propertyName) {
+        const ancestors = getAncestorsForConstructor(constructor);
+        return Array.from(ancestors.reduce((values, constructor) => {
+            getOwnStaticArrayValues(constructor, propertyName).forEach((name) => values.add(name));
+            return values;
+        }, new Set()));
+    }
+    function readInheritableStaticObjectPairs(constructor, propertyName) {
+        const ancestors = getAncestorsForConstructor(constructor);
+        return ancestors.reduce((pairs, constructor) => {
+            pairs.push(...getOwnStaticObjectPairs(constructor, propertyName));
+            return pairs;
+        }, []);
+    }
+    function getAncestorsForConstructor(constructor) {
+        const ancestors = [];
+        while (constructor) {
+            ancestors.push(constructor);
+            constructor = Object.getPrototypeOf(constructor);
+        }
+        return ancestors.reverse();
+    }
+    function getOwnStaticArrayValues(constructor, propertyName) {
+        const definition = constructor[propertyName];
+        return Array.isArray(definition) ? definition : [];
+    }
+    function getOwnStaticObjectPairs(constructor, propertyName) {
+        const definition = constructor[propertyName];
+        return definition ? Object.keys(definition).map((key) => [key, definition[key]]) : [];
+    }
+
+    class OutletObserver {
+        constructor(context, delegate) {
+            this.started = false;
+            this.context = context;
+            this.delegate = delegate;
+            this.outletsByName = new Multimap();
+            this.outletElementsByName = new Multimap();
+            this.selectorObserverMap = new Map();
+            this.attributeObserverMap = new Map();
+        }
+        start() {
+            if (!this.started) {
+                this.outletDefinitions.forEach((outletName) => {
+                    this.setupSelectorObserverForOutlet(outletName);
+                    this.setupAttributeObserverForOutlet(outletName);
+                });
+                this.started = true;
+                this.dependentContexts.forEach((context) => context.refresh());
+            }
+        }
+        refresh() {
+            this.selectorObserverMap.forEach((observer) => observer.refresh());
+            this.attributeObserverMap.forEach((observer) => observer.refresh());
+        }
+        stop() {
+            if (this.started) {
+                this.started = false;
+                this.disconnectAllOutlets();
+                this.stopSelectorObservers();
+                this.stopAttributeObservers();
+            }
+        }
+        stopSelectorObservers() {
+            if (this.selectorObserverMap.size > 0) {
+                this.selectorObserverMap.forEach((observer) => observer.stop());
+                this.selectorObserverMap.clear();
+            }
+        }
+        stopAttributeObservers() {
+            if (this.attributeObserverMap.size > 0) {
+                this.attributeObserverMap.forEach((observer) => observer.stop());
+                this.attributeObserverMap.clear();
+            }
+        }
+        selectorMatched(element, _selector, { outletName }) {
+            const outlet = this.getOutlet(element, outletName);
+            if (outlet) {
+                this.connectOutlet(outlet, element, outletName);
+            }
+        }
+        selectorUnmatched(element, _selector, { outletName }) {
+            const outlet = this.getOutletFromMap(element, outletName);
+            if (outlet) {
+                this.disconnectOutlet(outlet, element, outletName);
+            }
+        }
+        selectorMatchElement(element, { outletName }) {
+            const selector = this.selector(outletName);
+            const hasOutlet = this.hasOutlet(element, outletName);
+            const hasOutletController = element.matches(`[${this.schema.controllerAttribute}~=${outletName}]`);
+            if (selector) {
+                return hasOutlet && hasOutletController && element.matches(selector);
+            }
+            else {
+                return false;
+            }
+        }
+        elementMatchedAttribute(_element, attributeName) {
+            const outletName = this.getOutletNameFromOutletAttributeName(attributeName);
+            if (outletName) {
+                this.updateSelectorObserverForOutlet(outletName);
+            }
+        }
+        elementAttributeValueChanged(_element, attributeName) {
+            const outletName = this.getOutletNameFromOutletAttributeName(attributeName);
+            if (outletName) {
+                this.updateSelectorObserverForOutlet(outletName);
+            }
+        }
+        elementUnmatchedAttribute(_element, attributeName) {
+            const outletName = this.getOutletNameFromOutletAttributeName(attributeName);
+            if (outletName) {
+                this.updateSelectorObserverForOutlet(outletName);
+            }
+        }
+        connectOutlet(outlet, element, outletName) {
+            var _a;
+            if (!this.outletElementsByName.has(outletName, element)) {
+                this.outletsByName.add(outletName, outlet);
+                this.outletElementsByName.add(outletName, element);
+                (_a = this.selectorObserverMap.get(outletName)) === null || _a === void 0 ? void 0 : _a.pause(() => this.delegate.outletConnected(outlet, element, outletName));
+            }
+        }
+        disconnectOutlet(outlet, element, outletName) {
+            var _a;
+            if (this.outletElementsByName.has(outletName, element)) {
+                this.outletsByName.delete(outletName, outlet);
+                this.outletElementsByName.delete(outletName, element);
+                (_a = this.selectorObserverMap
+                    .get(outletName)) === null || _a === void 0 ? void 0 : _a.pause(() => this.delegate.outletDisconnected(outlet, element, outletName));
+            }
+        }
+        disconnectAllOutlets() {
+            for (const outletName of this.outletElementsByName.keys) {
+                for (const element of this.outletElementsByName.getValuesForKey(outletName)) {
+                    for (const outlet of this.outletsByName.getValuesForKey(outletName)) {
+                        this.disconnectOutlet(outlet, element, outletName);
+                    }
+                }
+            }
+        }
+        updateSelectorObserverForOutlet(outletName) {
+            const observer = this.selectorObserverMap.get(outletName);
+            if (observer) {
+                observer.selector = this.selector(outletName);
+            }
+        }
+        setupSelectorObserverForOutlet(outletName) {
+            const selector = this.selector(outletName);
+            const selectorObserver = new SelectorObserver(document.body, selector, this, { outletName });
+            this.selectorObserverMap.set(outletName, selectorObserver);
+            selectorObserver.start();
+        }
+        setupAttributeObserverForOutlet(outletName) {
+            const attributeName = this.attributeNameForOutletName(outletName);
+            const attributeObserver = new AttributeObserver(this.scope.element, attributeName, this);
+            this.attributeObserverMap.set(outletName, attributeObserver);
+            attributeObserver.start();
+        }
+        selector(outletName) {
+            return this.scope.outlets.getSelectorForOutletName(outletName);
+        }
+        attributeNameForOutletName(outletName) {
+            return this.scope.schema.outletAttributeForScope(this.identifier, outletName);
+        }
+        getOutletNameFromOutletAttributeName(attributeName) {
+            return this.outletDefinitions.find((outletName) => this.attributeNameForOutletName(outletName) === attributeName);
+        }
+        get outletDependencies() {
+            const dependencies = new Multimap();
+            this.router.modules.forEach((module) => {
+                const constructor = module.definition.controllerConstructor;
+                const outlets = readInheritableStaticArrayValues(constructor, "outlets");
+                outlets.forEach((outlet) => dependencies.add(outlet, module.identifier));
+            });
+            return dependencies;
+        }
+        get outletDefinitions() {
+            return this.outletDependencies.getKeysForValue(this.identifier);
+        }
+        get dependentControllerIdentifiers() {
+            return this.outletDependencies.getValuesForKey(this.identifier);
+        }
+        get dependentContexts() {
+            const identifiers = this.dependentControllerIdentifiers;
+            return this.router.contexts.filter((context) => identifiers.includes(context.identifier));
+        }
+        hasOutlet(element, outletName) {
+            return !!this.getOutlet(element, outletName) || !!this.getOutletFromMap(element, outletName);
+        }
+        getOutlet(element, outletName) {
+            return this.application.getControllerForElementAndIdentifier(element, outletName);
+        }
+        getOutletFromMap(element, outletName) {
+            return this.outletsByName.getValuesForKey(outletName).find((outlet) => outlet.element === element);
+        }
+        get scope() {
+            return this.context.scope;
+        }
+        get schema() {
+            return this.context.schema;
+        }
+        get identifier() {
+            return this.context.identifier;
+        }
+        get application() {
+            return this.context.application;
+        }
+        get router() {
+            return this.application.router;
+        }
+    }
+
+    class Context {
+        constructor(module, scope) {
+            this.logDebugActivity = (functionName, detail = {}) => {
+                const { identifier, controller, element } = this;
+                detail = Object.assign({ identifier, controller, element }, detail);
+                this.application.logDebugActivity(this.identifier, functionName, detail);
+            };
+            this.module = module;
+            this.scope = scope;
+            this.controller = new module.controllerConstructor(this);
+            this.bindingObserver = new BindingObserver(this, this.dispatcher);
+            this.valueObserver = new ValueObserver(this, this.controller);
+            this.targetObserver = new TargetObserver(this, this);
+            this.outletObserver = new OutletObserver(this, this);
+            try {
+                this.controller.initialize();
+                this.logDebugActivity("initialize");
+            }
+            catch (error) {
+                this.handleError(error, "initializing controller");
+            }
+        }
+        connect() {
+            this.bindingObserver.start();
+            this.valueObserver.start();
+            this.targetObserver.start();
+            this.outletObserver.start();
+            try {
+                this.controller.connect();
+                this.logDebugActivity("connect");
+            }
+            catch (error) {
+                this.handleError(error, "connecting controller");
+            }
+        }
+        refresh() {
+            this.outletObserver.refresh();
+        }
+        disconnect() {
+            try {
+                this.controller.disconnect();
+                this.logDebugActivity("disconnect");
+            }
+            catch (error) {
+                this.handleError(error, "disconnecting controller");
+            }
+            this.outletObserver.stop();
+            this.targetObserver.stop();
+            this.valueObserver.stop();
+            this.bindingObserver.stop();
+        }
+        get application() {
+            return this.module.application;
+        }
+        get identifier() {
+            return this.module.identifier;
+        }
+        get schema() {
+            return this.application.schema;
+        }
+        get dispatcher() {
+            return this.application.dispatcher;
+        }
+        get element() {
+            return this.scope.element;
+        }
+        get parentElement() {
+            return this.element.parentElement;
+        }
+        handleError(error, message, detail = {}) {
+            const { identifier, controller, element } = this;
+            detail = Object.assign({ identifier, controller, element }, detail);
+            this.application.handleError(error, `Error ${message}`, detail);
+        }
+        targetConnected(element, name) {
+            this.invokeControllerMethod(`${name}TargetConnected`, element);
+        }
+        targetDisconnected(element, name) {
+            this.invokeControllerMethod(`${name}TargetDisconnected`, element);
+        }
+        outletConnected(outlet, element, name) {
+            this.invokeControllerMethod(`${namespaceCamelize(name)}OutletConnected`, outlet, element);
+        }
+        outletDisconnected(outlet, element, name) {
+            this.invokeControllerMethod(`${namespaceCamelize(name)}OutletDisconnected`, outlet, element);
+        }
+        invokeControllerMethod(methodName, ...args) {
+            const controller = this.controller;
+            if (typeof controller[methodName] == "function") {
+                controller[methodName](...args);
+            }
+        }
+    }
+
+    function bless(constructor) {
+        return shadow(constructor, getBlessedProperties(constructor));
+    }
+    function shadow(constructor, properties) {
+        const shadowConstructor = extend(constructor);
+        const shadowProperties = getShadowProperties(constructor.prototype, properties);
+        Object.defineProperties(shadowConstructor.prototype, shadowProperties);
+        return shadowConstructor;
+    }
+    function getBlessedProperties(constructor) {
+        const blessings = readInheritableStaticArrayValues(constructor, "blessings");
+        return blessings.reduce((blessedProperties, blessing) => {
+            const properties = blessing(constructor);
+            for (const key in properties) {
+                const descriptor = blessedProperties[key] || {};
+                blessedProperties[key] = Object.assign(descriptor, properties[key]);
+            }
+            return blessedProperties;
+        }, {});
+    }
+    function getShadowProperties(prototype, properties) {
+        return getOwnKeys(properties).reduce((shadowProperties, key) => {
+            const descriptor = getShadowedDescriptor(prototype, properties, key);
+            if (descriptor) {
+                Object.assign(shadowProperties, { [key]: descriptor });
+            }
+            return shadowProperties;
+        }, {});
+    }
+    function getShadowedDescriptor(prototype, properties, key) {
+        const shadowingDescriptor = Object.getOwnPropertyDescriptor(prototype, key);
+        const shadowedByValue = shadowingDescriptor && "value" in shadowingDescriptor;
+        if (!shadowedByValue) {
+            const descriptor = Object.getOwnPropertyDescriptor(properties, key).value;
+            if (shadowingDescriptor) {
+                descriptor.get = shadowingDescriptor.get || descriptor.get;
+                descriptor.set = shadowingDescriptor.set || descriptor.set;
+            }
+            return descriptor;
+        }
+    }
+    const getOwnKeys = (() => {
+        if (typeof Object.getOwnPropertySymbols == "function") {
+            return (object) => [...Object.getOwnPropertyNames(object), ...Object.getOwnPropertySymbols(object)];
+        }
+        else {
+            return Object.getOwnPropertyNames;
+        }
+    })();
+    const extend = (() => {
+        function extendWithReflect(constructor) {
+            function extended() {
+                return Reflect.construct(constructor, arguments, new.target);
+            }
+            extended.prototype = Object.create(constructor.prototype, {
+                constructor: { value: extended },
+            });
+            Reflect.setPrototypeOf(extended, constructor);
+            return extended;
+        }
+        function testReflectExtension() {
+            const a = function () {
+                this.a.call(this);
+            };
+            const b = extendWithReflect(a);
+            b.prototype.a = function () { };
+            return new b();
+        }
+        try {
+            testReflectExtension();
+            return extendWithReflect;
+        }
+        catch (error) {
+            return (constructor) => class extended extends constructor {
+            };
+        }
+    })();
+
+    function blessDefinition(definition) {
+        return {
+            identifier: definition.identifier,
+            controllerConstructor: bless(definition.controllerConstructor),
+        };
+    }
+
+    class Module {
+        constructor(application, definition) {
+            this.application = application;
+            this.definition = blessDefinition(definition);
+            this.contextsByScope = new WeakMap();
+            this.connectedContexts = new Set();
+        }
+        get identifier() {
+            return this.definition.identifier;
+        }
+        get controllerConstructor() {
+            return this.definition.controllerConstructor;
+        }
+        get contexts() {
+            return Array.from(this.connectedContexts);
+        }
+        connectContextForScope(scope) {
+            const context = this.fetchContextForScope(scope);
+            this.connectedContexts.add(context);
+            context.connect();
+        }
+        disconnectContextForScope(scope) {
+            const context = this.contextsByScope.get(scope);
+            if (context) {
+                this.connectedContexts.delete(context);
+                context.disconnect();
+            }
+        }
+        fetchContextForScope(scope) {
+            let context = this.contextsByScope.get(scope);
+            if (!context) {
+                context = new Context(this, scope);
+                this.contextsByScope.set(scope, context);
+            }
+            return context;
+        }
+    }
+
+    class ClassMap {
+        constructor(scope) {
+            this.scope = scope;
+        }
+        has(name) {
+            return this.data.has(this.getDataKey(name));
+        }
+        get(name) {
+            return this.getAll(name)[0];
+        }
+        getAll(name) {
+            const tokenString = this.data.get(this.getDataKey(name)) || "";
+            return tokenize(tokenString);
+        }
+        getAttributeName(name) {
+            return this.data.getAttributeNameForKey(this.getDataKey(name));
+        }
+        getDataKey(name) {
+            return `${name}-class`;
+        }
+        get data() {
+            return this.scope.data;
+        }
+    }
+
+    class DataMap {
+        constructor(scope) {
+            this.scope = scope;
+        }
+        get element() {
+            return this.scope.element;
+        }
+        get identifier() {
+            return this.scope.identifier;
+        }
+        get(key) {
+            const name = this.getAttributeNameForKey(key);
+            return this.element.getAttribute(name);
+        }
+        set(key, value) {
+            const name = this.getAttributeNameForKey(key);
+            this.element.setAttribute(name, value);
+            return this.get(key);
+        }
+        has(key) {
+            const name = this.getAttributeNameForKey(key);
+            return this.element.hasAttribute(name);
+        }
+        delete(key) {
+            if (this.has(key)) {
+                const name = this.getAttributeNameForKey(key);
+                this.element.removeAttribute(name);
+                return true;
+            }
+            else {
+                return false;
+            }
+        }
+        getAttributeNameForKey(key) {
+            return `data-${this.identifier}-${dasherize(key)}`;
+        }
+    }
+
+    class Guide {
+        constructor(logger) {
+            this.warnedKeysByObject = new WeakMap();
+            this.logger = logger;
+        }
+        warn(object, key, message) {
+            let warnedKeys = this.warnedKeysByObject.get(object);
+            if (!warnedKeys) {
+                warnedKeys = new Set();
+                this.warnedKeysByObject.set(object, warnedKeys);
+            }
+            if (!warnedKeys.has(key)) {
+                warnedKeys.add(key);
+                this.logger.warn(message, object);
+            }
+        }
+    }
+
+    function attributeValueContainsToken(attributeName, token) {
+        return `[${attributeName}~="${token}"]`;
+    }
+
+    class TargetSet {
+        constructor(scope) {
+            this.scope = scope;
+        }
+        get element() {
+            return this.scope.element;
+        }
+        get identifier() {
+            return this.scope.identifier;
+        }
+        get schema() {
+            return this.scope.schema;
+        }
+        has(targetName) {
+            return this.find(targetName) != null;
+        }
+        find(...targetNames) {
+            return targetNames.reduce((target, targetName) => target || this.findTarget(targetName) || this.findLegacyTarget(targetName), undefined);
+        }
+        findAll(...targetNames) {
+            return targetNames.reduce((targets, targetName) => [
+                ...targets,
+                ...this.findAllTargets(targetName),
+                ...this.findAllLegacyTargets(targetName),
+            ], []);
+        }
+        findTarget(targetName) {
+            const selector = this.getSelectorForTargetName(targetName);
+            return this.scope.findElement(selector);
+        }
+        findAllTargets(targetName) {
+            const selector = this.getSelectorForTargetName(targetName);
+            return this.scope.findAllElements(selector);
+        }
+        getSelectorForTargetName(targetName) {
+            const attributeName = this.schema.targetAttributeForScope(this.identifier);
+            return attributeValueContainsToken(attributeName, targetName);
+        }
+        findLegacyTarget(targetName) {
+            const selector = this.getLegacySelectorForTargetName(targetName);
+            return this.deprecate(this.scope.findElement(selector), targetName);
+        }
+        findAllLegacyTargets(targetName) {
+            const selector = this.getLegacySelectorForTargetName(targetName);
+            return this.scope.findAllElements(selector).map((element) => this.deprecate(element, targetName));
+        }
+        getLegacySelectorForTargetName(targetName) {
+            const targetDescriptor = `${this.identifier}.${targetName}`;
+            return attributeValueContainsToken(this.schema.targetAttribute, targetDescriptor);
+        }
+        deprecate(element, targetName) {
+            if (element) {
+                const { identifier } = this;
+                const attributeName = this.schema.targetAttribute;
+                const revisedAttributeName = this.schema.targetAttributeForScope(identifier);
+                this.guide.warn(element, `target:${targetName}`, `Please replace ${attributeName}="${identifier}.${targetName}" with ${revisedAttributeName}="${targetName}". ` +
+                    `The ${attributeName} attribute is deprecated and will be removed in a future version of Stimulus.`);
+            }
+            return element;
+        }
+        get guide() {
+            return this.scope.guide;
+        }
+    }
+
+    class OutletSet {
+        constructor(scope, controllerElement) {
+            this.scope = scope;
+            this.controllerElement = controllerElement;
+        }
+        get element() {
+            return this.scope.element;
+        }
+        get identifier() {
+            return this.scope.identifier;
+        }
+        get schema() {
+            return this.scope.schema;
+        }
+        has(outletName) {
+            return this.find(outletName) != null;
+        }
+        find(...outletNames) {
+            return outletNames.reduce((outlet, outletName) => outlet || this.findOutlet(outletName), undefined);
+        }
+        findAll(...outletNames) {
+            return outletNames.reduce((outlets, outletName) => [...outlets, ...this.findAllOutlets(outletName)], []);
+        }
+        getSelectorForOutletName(outletName) {
+            const attributeName = this.schema.outletAttributeForScope(this.identifier, outletName);
+            return this.controllerElement.getAttribute(attributeName);
+        }
+        findOutlet(outletName) {
+            const selector = this.getSelectorForOutletName(outletName);
+            if (selector)
+                return this.findElement(selector, outletName);
+        }
+        findAllOutlets(outletName) {
+            const selector = this.getSelectorForOutletName(outletName);
+            return selector ? this.findAllElements(selector, outletName) : [];
+        }
+        findElement(selector, outletName) {
+            const elements = this.scope.queryElements(selector);
+            return elements.filter((element) => this.matchesElement(element, selector, outletName))[0];
+        }
+        findAllElements(selector, outletName) {
+            const elements = this.scope.queryElements(selector);
+            return elements.filter((element) => this.matchesElement(element, selector, outletName));
+        }
+        matchesElement(element, selector, outletName) {
+            const controllerAttribute = element.getAttribute(this.scope.schema.controllerAttribute) || "";
+            return element.matches(selector) && controllerAttribute.split(" ").includes(outletName);
+        }
+    }
+
+    class Scope {
+        constructor(schema, element, identifier, logger) {
+            this.targets = new TargetSet(this);
+            this.classes = new ClassMap(this);
+            this.data = new DataMap(this);
+            this.containsElement = (element) => {
+                return element.closest(this.controllerSelector) === this.element;
+            };
+            this.schema = schema;
+            this.element = element;
+            this.identifier = identifier;
+            this.guide = new Guide(logger);
+            this.outlets = new OutletSet(this.documentScope, element);
+        }
+        findElement(selector) {
+            return this.element.matches(selector) ? this.element : this.queryElements(selector).find(this.containsElement);
+        }
+        findAllElements(selector) {
+            return [
+                ...(this.element.matches(selector) ? [this.element] : []),
+                ...this.queryElements(selector).filter(this.containsElement),
+            ];
+        }
+        queryElements(selector) {
+            return Array.from(this.element.querySelectorAll(selector));
+        }
+        get controllerSelector() {
+            return attributeValueContainsToken(this.schema.controllerAttribute, this.identifier);
+        }
+        get isDocumentScope() {
+            return this.element === document.documentElement;
+        }
+        get documentScope() {
+            return this.isDocumentScope
+                ? this
+                : new Scope(this.schema, document.documentElement, this.identifier, this.guide.logger);
+        }
+    }
+
+    class ScopeObserver {
+        constructor(element, schema, delegate) {
+            this.element = element;
+            this.schema = schema;
+            this.delegate = delegate;
+            this.valueListObserver = new ValueListObserver(this.element, this.controllerAttribute, this);
+            this.scopesByIdentifierByElement = new WeakMap();
+            this.scopeReferenceCounts = new WeakMap();
+        }
+        start() {
+            this.valueListObserver.start();
+        }
+        stop() {
+            this.valueListObserver.stop();
+        }
+        get controllerAttribute() {
+            return this.schema.controllerAttribute;
+        }
+        parseValueForToken(token) {
+            const { element, content: identifier } = token;
+            return this.parseValueForElementAndIdentifier(element, identifier);
+        }
+        parseValueForElementAndIdentifier(element, identifier) {
+            const scopesByIdentifier = this.fetchScopesByIdentifierForElement(element);
+            let scope = scopesByIdentifier.get(identifier);
+            if (!scope) {
+                scope = this.delegate.createScopeForElementAndIdentifier(element, identifier);
+                scopesByIdentifier.set(identifier, scope);
+            }
+            return scope;
+        }
+        elementMatchedValue(element, value) {
+            const referenceCount = (this.scopeReferenceCounts.get(value) || 0) + 1;
+            this.scopeReferenceCounts.set(value, referenceCount);
+            if (referenceCount == 1) {
+                this.delegate.scopeConnected(value);
+            }
+        }
+        elementUnmatchedValue(element, value) {
+            const referenceCount = this.scopeReferenceCounts.get(value);
+            if (referenceCount) {
+                this.scopeReferenceCounts.set(value, referenceCount - 1);
+                if (referenceCount == 1) {
+                    this.delegate.scopeDisconnected(value);
+                }
+            }
+        }
+        fetchScopesByIdentifierForElement(element) {
+            let scopesByIdentifier = this.scopesByIdentifierByElement.get(element);
+            if (!scopesByIdentifier) {
+                scopesByIdentifier = new Map();
+                this.scopesByIdentifierByElement.set(element, scopesByIdentifier);
+            }
+            return scopesByIdentifier;
+        }
+    }
+
+    class Router {
+        constructor(application) {
+            this.application = application;
+            this.scopeObserver = new ScopeObserver(this.element, this.schema, this);
+            this.scopesByIdentifier = new Multimap();
+            this.modulesByIdentifier = new Map();
+        }
+        get element() {
+            return this.application.element;
+        }
+        get schema() {
+            return this.application.schema;
+        }
+        get logger() {
+            return this.application.logger;
+        }
+        get controllerAttribute() {
+            return this.schema.controllerAttribute;
+        }
+        get modules() {
+            return Array.from(this.modulesByIdentifier.values());
+        }
+        get contexts() {
+            return this.modules.reduce((contexts, module) => contexts.concat(module.contexts), []);
+        }
+        start() {
+            this.scopeObserver.start();
+        }
+        stop() {
+            this.scopeObserver.stop();
+        }
+        loadDefinition(definition) {
+            this.unloadIdentifier(definition.identifier);
+            const module = new Module(this.application, definition);
+            this.connectModule(module);
+            const afterLoad = definition.controllerConstructor.afterLoad;
+            if (afterLoad) {
+                afterLoad.call(definition.controllerConstructor, definition.identifier, this.application);
+            }
+        }
+        unloadIdentifier(identifier) {
+            const module = this.modulesByIdentifier.get(identifier);
+            if (module) {
+                this.disconnectModule(module);
+            }
+        }
+        getContextForElementAndIdentifier(element, identifier) {
+            const module = this.modulesByIdentifier.get(identifier);
+            if (module) {
+                return module.contexts.find((context) => context.element == element);
+            }
+        }
+        proposeToConnectScopeForElementAndIdentifier(element, identifier) {
+            const scope = this.scopeObserver.parseValueForElementAndIdentifier(element, identifier);
+            if (scope) {
+                this.scopeObserver.elementMatchedValue(scope.element, scope);
+            }
+            else {
+                console.error(`Couldn't find or create scope for identifier: "${identifier}" and element:`, element);
+            }
+        }
+        handleError(error, message, detail) {
+            this.application.handleError(error, message, detail);
+        }
+        createScopeForElementAndIdentifier(element, identifier) {
+            return new Scope(this.schema, element, identifier, this.logger);
+        }
+        scopeConnected(scope) {
+            this.scopesByIdentifier.add(scope.identifier, scope);
+            const module = this.modulesByIdentifier.get(scope.identifier);
+            if (module) {
+                module.connectContextForScope(scope);
+            }
+        }
+        scopeDisconnected(scope) {
+            this.scopesByIdentifier.delete(scope.identifier, scope);
+            const module = this.modulesByIdentifier.get(scope.identifier);
+            if (module) {
+                module.disconnectContextForScope(scope);
+            }
+        }
+        connectModule(module) {
+            this.modulesByIdentifier.set(module.identifier, module);
+            const scopes = this.scopesByIdentifier.getValuesForKey(module.identifier);
+            scopes.forEach((scope) => module.connectContextForScope(scope));
+        }
+        disconnectModule(module) {
+            this.modulesByIdentifier.delete(module.identifier);
+            const scopes = this.scopesByIdentifier.getValuesForKey(module.identifier);
+            scopes.forEach((scope) => module.disconnectContextForScope(scope));
+        }
+    }
+
+    const defaultSchema = {
+        controllerAttribute: "data-controller",
+        actionAttribute: "data-action",
+        targetAttribute: "data-target",
+        targetAttributeForScope: (identifier) => `data-${identifier}-target`,
+        outletAttributeForScope: (identifier, outlet) => `data-${identifier}-${outlet}-outlet`,
+        keyMappings: Object.assign(Object.assign({ enter: "Enter", tab: "Tab", esc: "Escape", space: " ", up: "ArrowUp", down: "ArrowDown", left: "ArrowLeft", right: "ArrowRight", home: "Home", end: "End", page_up: "PageUp", page_down: "PageDown" }, objectFromEntries("abcdefghijklmnopqrstuvwxyz".split("").map((c) => [c, c]))), objectFromEntries("0123456789".split("").map((n) => [n, n]))),
+    };
+    function objectFromEntries(array) {
+        return array.reduce((memo, [k, v]) => (Object.assign(Object.assign({}, memo), { [k]: v })), {});
+    }
+
+    class Application {
+        constructor(element = document.documentElement, schema = defaultSchema) {
+            this.logger = console;
+            this.debug = false;
+            this.logDebugActivity = (identifier, functionName, detail = {}) => {
+                if (this.debug) {
+                    this.logFormattedMessage(identifier, functionName, detail);
+                }
+            };
+            this.element = element;
+            this.schema = schema;
+            this.dispatcher = new Dispatcher(this);
+            this.router = new Router(this);
+            this.actionDescriptorFilters = Object.assign({}, defaultActionDescriptorFilters);
+        }
+        static start(element, schema) {
+            const application = new this(element, schema);
+            application.start();
+            return application;
+        }
+        async start() {
+            await domReady();
+            this.logDebugActivity("application", "starting");
+            this.dispatcher.start();
+            this.router.start();
+            this.logDebugActivity("application", "start");
+        }
+        stop() {
+            this.logDebugActivity("application", "stopping");
+            this.dispatcher.stop();
+            this.router.stop();
+            this.logDebugActivity("application", "stop");
+        }
+        register(identifier, controllerConstructor) {
+            this.load({ identifier, controllerConstructor });
+        }
+        registerActionOption(name, filter) {
+            this.actionDescriptorFilters[name] = filter;
+        }
+        load(head, ...rest) {
+            const definitions = Array.isArray(head) ? head : [head, ...rest];
+            definitions.forEach((definition) => {
+                if (definition.controllerConstructor.shouldLoad) {
+                    this.router.loadDefinition(definition);
+                }
+            });
+        }
+        unload(head, ...rest) {
+            const identifiers = Array.isArray(head) ? head : [head, ...rest];
+            identifiers.forEach((identifier) => this.router.unloadIdentifier(identifier));
+        }
+        get controllers() {
+            return this.router.contexts.map((context) => context.controller);
+        }
+        getControllerForElementAndIdentifier(element, identifier) {
+            const context = this.router.getContextForElementAndIdentifier(element, identifier);
+            return context ? context.controller : null;
+        }
+        handleError(error, message, detail) {
+            var _a;
+            this.logger.error(`%s\n\n%o\n\n%o`, message, error, detail);
+            (_a = window.onerror) === null || _a === void 0 ? void 0 : _a.call(window, message, "", 0, 0, error);
+        }
+        logFormattedMessage(identifier, functionName, detail = {}) {
+            detail = Object.assign({ application: this }, detail);
+            this.logger.groupCollapsed(`${identifier} #${functionName}`);
+            this.logger.log("details:", Object.assign({}, detail));
+            this.logger.groupEnd();
+        }
+    }
+    function domReady() {
+        return new Promise((resolve) => {
+            if (document.readyState == "loading") {
+                document.addEventListener("DOMContentLoaded", () => resolve());
+            }
+            else {
+                resolve();
+            }
+        });
+    }
+
+    function ClassPropertiesBlessing(constructor) {
+        const classes = readInheritableStaticArrayValues(constructor, "classes");
+        return classes.reduce((properties, classDefinition) => {
+            return Object.assign(properties, propertiesForClassDefinition(classDefinition));
+        }, {});
+    }
+    function propertiesForClassDefinition(key) {
+        return {
+            [`${key}Class`]: {
+                get() {
+                    const { classes } = this;
+                    if (classes.has(key)) {
+                        return classes.get(key);
+                    }
+                    else {
+                        const attribute = classes.getAttributeName(key);
+                        throw new Error(`Missing attribute "${attribute}"`);
+                    }
+                },
+            },
+            [`${key}Classes`]: {
+                get() {
+                    return this.classes.getAll(key);
+                },
+            },
+            [`has${capitalize(key)}Class`]: {
+                get() {
+                    return this.classes.has(key);
+                },
+            },
+        };
+    }
+
+    function OutletPropertiesBlessing(constructor) {
+        const outlets = readInheritableStaticArrayValues(constructor, "outlets");
+        return outlets.reduce((properties, outletDefinition) => {
+            return Object.assign(properties, propertiesForOutletDefinition(outletDefinition));
+        }, {});
+    }
+    function getOutletController(controller, element, identifier) {
+        return controller.application.getControllerForElementAndIdentifier(element, identifier);
+    }
+    function getControllerAndEnsureConnectedScope(controller, element, outletName) {
+        let outletController = getOutletController(controller, element, outletName);
+        if (outletController)
+            return outletController;
+        controller.application.router.proposeToConnectScopeForElementAndIdentifier(element, outletName);
+        outletController = getOutletController(controller, element, outletName);
+        if (outletController)
+            return outletController;
+    }
+    function propertiesForOutletDefinition(name) {
+        const camelizedName = namespaceCamelize(name);
+        return {
+            [`${camelizedName}Outlet`]: {
+                get() {
+                    const outletElement = this.outlets.find(name);
+                    const selector = this.outlets.getSelectorForOutletName(name);
+                    if (outletElement) {
+                        const outletController = getControllerAndEnsureConnectedScope(this, outletElement, name);
+                        if (outletController)
+                            return outletController;
+                        throw new Error(`The provided outlet element is missing an outlet controller "${name}" instance for host controller "${this.identifier}"`);
+                    }
+                    throw new Error(`Missing outlet element "${name}" for host controller "${this.identifier}". Stimulus couldn't find a matching outlet element using selector "${selector}".`);
+                },
+            },
+            [`${camelizedName}Outlets`]: {
+                get() {
+                    const outlets = this.outlets.findAll(name);
+                    if (outlets.length > 0) {
+                        return outlets
+                            .map((outletElement) => {
+                            const outletController = getControllerAndEnsureConnectedScope(this, outletElement, name);
+                            if (outletController)
+                                return outletController;
+                            console.warn(`The provided outlet element is missing an outlet controller "${name}" instance for host controller "${this.identifier}"`, outletElement);
+                        })
+                            .filter((controller) => controller);
+                    }
+                    return [];
+                },
+            },
+            [`${camelizedName}OutletElement`]: {
+                get() {
+                    const outletElement = this.outlets.find(name);
+                    const selector = this.outlets.getSelectorForOutletName(name);
+                    if (outletElement) {
+                        return outletElement;
+                    }
+                    else {
+                        throw new Error(`Missing outlet element "${name}" for host controller "${this.identifier}". Stimulus couldn't find a matching outlet element using selector "${selector}".`);
+                    }
+                },
+            },
+            [`${camelizedName}OutletElements`]: {
+                get() {
+                    return this.outlets.findAll(name);
+                },
+            },
+            [`has${capitalize(camelizedName)}Outlet`]: {
+                get() {
+                    return this.outlets.has(name);
+                },
+            },
+        };
+    }
+
+    function TargetPropertiesBlessing(constructor) {
+        const targets = readInheritableStaticArrayValues(constructor, "targets");
+        return targets.reduce((properties, targetDefinition) => {
+            return Object.assign(properties, propertiesForTargetDefinition(targetDefinition));
+        }, {});
+    }
+    function propertiesForTargetDefinition(name) {
+        return {
+            [`${name}Target`]: {
+                get() {
+                    const target = this.targets.find(name);
+                    if (target) {
+                        return target;
+                    }
+                    else {
+                        throw new Error(`Missing target element "${name}" for "${this.identifier}" controller`);
+                    }
+                },
+            },
+            [`${name}Targets`]: {
+                get() {
+                    return this.targets.findAll(name);
+                },
+            },
+            [`has${capitalize(name)}Target`]: {
+                get() {
+                    return this.targets.has(name);
+                },
+            },
+        };
+    }
+
+    function ValuePropertiesBlessing(constructor) {
+        const valueDefinitionPairs = readInheritableStaticObjectPairs(constructor, "values");
+        const propertyDescriptorMap = {
+            valueDescriptorMap: {
+                get() {
+                    return valueDefinitionPairs.reduce((result, valueDefinitionPair) => {
+                        const valueDescriptor = parseValueDefinitionPair(valueDefinitionPair, this.identifier);
+                        const attributeName = this.data.getAttributeNameForKey(valueDescriptor.key);
+                        return Object.assign(result, { [attributeName]: valueDescriptor });
+                    }, {});
+                },
+            },
+        };
+        return valueDefinitionPairs.reduce((properties, valueDefinitionPair) => {
+            return Object.assign(properties, propertiesForValueDefinitionPair(valueDefinitionPair));
+        }, propertyDescriptorMap);
+    }
+    function propertiesForValueDefinitionPair(valueDefinitionPair, controller) {
+        const definition = parseValueDefinitionPair(valueDefinitionPair, controller);
+        const { key, name, reader: read, writer: write } = definition;
+        return {
+            [name]: {
+                get() {
+                    const value = this.data.get(key);
+                    if (value !== null) {
+                        return read(value);
+                    }
+                    else {
+                        return definition.defaultValue;
+                    }
+                },
+                set(value) {
+                    if (value === undefined) {
+                        this.data.delete(key);
+                    }
+                    else {
+                        this.data.set(key, write(value));
+                    }
+                },
+            },
+            [`has${capitalize(name)}`]: {
+                get() {
+                    return this.data.has(key) || definition.hasCustomDefaultValue;
+                },
+            },
+        };
+    }
+    function parseValueDefinitionPair([token, typeDefinition], controller) {
+        return valueDescriptorForTokenAndTypeDefinition({
+            controller,
+            token,
+            typeDefinition,
+        });
+    }
+    function parseValueTypeConstant(constant) {
+        switch (constant) {
+            case Array:
+                return "array";
+            case Boolean:
+                return "boolean";
+            case Number:
+                return "number";
+            case Object:
+                return "object";
+            case String:
+                return "string";
+        }
+    }
+    function parseValueTypeDefault(defaultValue) {
+        switch (typeof defaultValue) {
+            case "boolean":
+                return "boolean";
+            case "number":
+                return "number";
+            case "string":
+                return "string";
+        }
+        if (Array.isArray(defaultValue))
+            return "array";
+        if (Object.prototype.toString.call(defaultValue) === "[object Object]")
+            return "object";
+    }
+    function parseValueTypeObject(payload) {
+        const { controller, token, typeObject } = payload;
+        const hasType = isSomething(typeObject.type);
+        const hasDefault = isSomething(typeObject.default);
+        const fullObject = hasType && hasDefault;
+        const onlyType = hasType && !hasDefault;
+        const onlyDefault = !hasType && hasDefault;
+        const typeFromObject = parseValueTypeConstant(typeObject.type);
+        const typeFromDefaultValue = parseValueTypeDefault(payload.typeObject.default);
+        if (onlyType)
+            return typeFromObject;
+        if (onlyDefault)
+            return typeFromDefaultValue;
+        if (typeFromObject !== typeFromDefaultValue) {
+            const propertyPath = controller ? `${controller}.${token}` : token;
+            throw new Error(`The specified default value for the Stimulus Value "${propertyPath}" must match the defined type "${typeFromObject}". The provided default value of "${typeObject.default}" is of type "${typeFromDefaultValue}".`);
+        }
+        if (fullObject)
+            return typeFromObject;
+    }
+    function parseValueTypeDefinition(payload) {
+        const { controller, token, typeDefinition } = payload;
+        const typeObject = { controller, token, typeObject: typeDefinition };
+        const typeFromObject = parseValueTypeObject(typeObject);
+        const typeFromDefaultValue = parseValueTypeDefault(typeDefinition);
+        const typeFromConstant = parseValueTypeConstant(typeDefinition);
+        const type = typeFromObject || typeFromDefaultValue || typeFromConstant;
+        if (type)
+            return type;
+        const propertyPath = controller ? `${controller}.${typeDefinition}` : token;
+        throw new Error(`Unknown value type "${propertyPath}" for "${token}" value`);
+    }
+    function defaultValueForDefinition(typeDefinition) {
+        const constant = parseValueTypeConstant(typeDefinition);
+        if (constant)
+            return defaultValuesByType[constant];
+        const hasDefault = hasProperty(typeDefinition, "default");
+        const hasType = hasProperty(typeDefinition, "type");
+        const typeObject = typeDefinition;
+        if (hasDefault)
+            return typeObject.default;
+        if (hasType) {
+            const { type } = typeObject;
+            const constantFromType = parseValueTypeConstant(type);
+            if (constantFromType)
+                return defaultValuesByType[constantFromType];
+        }
+        return typeDefinition;
+    }
+    function valueDescriptorForTokenAndTypeDefinition(payload) {
+        const { token, typeDefinition } = payload;
+        const key = `${dasherize(token)}-value`;
+        const type = parseValueTypeDefinition(payload);
+        return {
+            type,
+            key,
+            name: camelize(key),
+            get defaultValue() {
+                return defaultValueForDefinition(typeDefinition);
+            },
+            get hasCustomDefaultValue() {
+                return parseValueTypeDefault(typeDefinition) !== undefined;
+            },
+            reader: readers[type],
+            writer: writers[type] || writers.default,
+        };
+    }
+    const defaultValuesByType = {
+        get array() {
+            return [];
+        },
+        boolean: false,
+        number: 0,
+        get object() {
+            return {};
+        },
+        string: "",
+    };
+    const readers = {
+        array(value) {
+            const array = JSON.parse(value);
+            if (!Array.isArray(array)) {
+                throw new TypeError(`expected value of type "array" but instead got value "${value}" of type "${parseValueTypeDefault(array)}"`);
+            }
+            return array;
+        },
+        boolean(value) {
+            return !(value == "0" || String(value).toLowerCase() == "false");
+        },
+        number(value) {
+            return Number(value.replace(/_/g, ""));
+        },
+        object(value) {
+            const object = JSON.parse(value);
+            if (object === null || typeof object != "object" || Array.isArray(object)) {
+                throw new TypeError(`expected value of type "object" but instead got value "${value}" of type "${parseValueTypeDefault(object)}"`);
+            }
+            return object;
+        },
+        string(value) {
+            return value;
+        },
+    };
+    const writers = {
+        default: writeString,
+        array: writeJSON,
+        object: writeJSON,
+    };
+    function writeJSON(value) {
+        return JSON.stringify(value);
+    }
+    function writeString(value) {
+        return `${value}`;
+    }
+
+    class Controller {
+        constructor(context) {
+            this.context = context;
+        }
+        static get shouldLoad() {
+            return true;
+        }
+        static afterLoad(_identifier, _application) {
+            return;
+        }
+        get application() {
+            return this.context.application;
+        }
+        get scope() {
+            return this.context.scope;
+        }
+        get element() {
+            return this.scope.element;
+        }
+        get identifier() {
+            return this.scope.identifier;
+        }
+        get targets() {
+            return this.scope.targets;
+        }
+        get outlets() {
+            return this.scope.outlets;
+        }
+        get classes() {
+            return this.scope.classes;
+        }
+        get data() {
+            return this.scope.data;
+        }
+        initialize() {
+        }
+        connect() {
+        }
+        disconnect() {
+        }
+        dispatch(eventName, { target = this.element, detail = {}, prefix = this.identifier, bubbles = true, cancelable = true, } = {}) {
+            const type = prefix ? `${prefix}:${eventName}` : eventName;
+            const event = new CustomEvent(type, { detail, bubbles, cancelable });
+            target.dispatchEvent(event);
+            return event;
+        }
+    }
+    Controller.blessings = [
+        ClassPropertiesBlessing,
+        TargetPropertiesBlessing,
+        ValuePropertiesBlessing,
+        OutletPropertiesBlessing,
+    ];
+    Controller.targets = [];
+    Controller.outlets = [];
+    Controller.values = {};
+
+    exports.Application = Application;
+    exports.AttributeObserver = AttributeObserver;
+    exports.Context = Context;
+    exports.Controller = Controller;
+    exports.ElementObserver = ElementObserver;
+    exports.IndexedMultimap = IndexedMultimap;
+    exports.Multimap = Multimap;
+    exports.SelectorObserver = SelectorObserver;
+    exports.StringMapObserver = StringMapObserver;
+    exports.TokenListObserver = TokenListObserver;
+    exports.ValueListObserver = ValueListObserver;
+    exports.add = add;
+    exports.defaultSchema = defaultSchema;
+    exports.del = del;
+    exports.fetch = fetch;
+    exports.prune = prune;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/test/system/test_support.rb
+++ b/test/system/test_support.rb
@@ -9,8 +9,20 @@ require 'capybara/dsl'
 begin
   require 'capybara/cuprite'
 
+  # CI runners (and Docker containers) run as root, so Chrome requires
+  # --no-sandbox.  Increasing process_timeout from the Ferrum default of
+  # 10s to 30s accommodates slow CI runners launching modern Chrome/Chromium.
   Capybara.register_driver(:number_flow_cuprite) do |app|
-    Capybara::Cuprite::Driver.new(app, headless: true, js_errors: true, window_size: [1280, 720])
+    Capybara::Cuprite::Driver.new(app,
+                                  headless: true,
+                                  js_errors: true,
+                                  window_size: [1280, 720],
+                                  process_timeout: 30,
+                                  browser_options: {
+                                    'no-sandbox' => nil,
+                                    'disable-gpu' => nil,
+                                    'disable-dev-shm-usage' => nil
+                                  })
   end
 
   Capybara.default_driver = :number_flow_cuprite
@@ -85,9 +97,9 @@ module NumberFlow
         "data-number-flow-duration-value=\"#{duration}\"",
         "data-number-flow-easing-value=\"#{easing}\"",
         "data-number-flow-stagger-value=\"#{stagger}\"",
-        "data-number-flow-grouping-value=\"#{grouping}\"",
-        "data-number-flow-precision-value=\"#{precision}\""
+        "data-number-flow-grouping-value=\"#{grouping}\""
       ]
+      data_attrs << "data-number-flow-precision-value=\"#{precision}\"" if precision.positive?
       data_attrs << "data-number-flow-locale-value=\"#{locale}\"" if locale
 
       # Build digit spans

--- a/test/system/test_support.rb
+++ b/test/system/test_support.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+# Test support for browser-based system tests using Cuprite (headless Chrome).
+# This file is only required when system tests are active (RUN_SYSTEM_TESTS=true).
+
+require 'capybara'
+require 'capybara/dsl'
+
+begin
+  require 'capybara/cuprite'
+
+  Capybara.register_driver(:number_flow_cuprite) do |app|
+    Capybara::Cuprite::Driver.new(app, headless: true, js_errors: true, window_size: [1280, 720])
+  end
+
+  Capybara.default_driver = :number_flow_cuprite
+  Capybara.javascript_driver = :number_flow_cuprite
+  Capybara.current_driver = :number_flow_cuprite
+rescue LoadError
+  # cuprite not available — system tests will be skipped.
+end
+
+Capybara.server = :webrick
+Capybara.server_host = '127.0.0.1'
+Capybara.default_max_wait_time = 5
+
+module NumberFlow
+  module SystemTestHelper
+    CONTROLLER_JS_PATH = File.expand_path('../../app/assets/javascripts/number_flow/controller.js', __dir__)
+    CSS_PATH = File.expand_path('../../app/assets/stylesheets/number_flow.css', __dir__)
+    STIMULUS_PATH = File.expand_path('support/stimulus.js', __dir__)
+
+    def build_html_page(initial_html: '')
+      css = File.read(CSS_PATH)
+      stimulus_js = File.read(STIMULUS_PATH)
+
+      <<~HTML
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="utf-8">
+          <title>NumberFlow System Test</title>
+          <style>#{css}</style>
+        </head>
+        <body>
+          <div id="container">#{initial_html}</div>
+          <script>#{stimulus_js}</script>
+          <script>
+            var StimulusApp = Stimulus.Application.start();
+            #{register_controller_js}
+          </script>
+        </body>
+        </html>
+      HTML
+    end
+
+    private
+
+    def register_controller_js
+      controller_source = File.read(CONTROLLER_JS_PATH)
+      # Extract the class body (remove ESM import lines)
+      class_body = controller_source.gsub(/^import .*/, '').strip
+      # Replace ESM export syntax for inline browser use
+      class_body = class_body.sub(/^export default class extends Controller/,
+                                  'class NumberFlowController extends Stimulus.Controller')
+
+      <<-JS
+        #{class_body}
+        StimulusApp.register("number-flow", NumberFlowController);
+        window.StimulusApp = StimulusApp;
+      JS
+    end
+
+    def build_number_flow_markup(value, **options)
+      precision = options.fetch(:precision, 0)
+      duration = options.fetch(:duration, 400)
+      easing = options.fetch(:easing, 'cubic-bezier(0.2, 0, 0, 1)')
+      stagger = options.fetch(:stagger, 20)
+      grouping = options.fetch(:grouping, false)
+      locale = options[:locale]
+
+      data_attrs = [
+        'data-controller="number-flow"',
+        "data-number-flow-value-value=\"#{value}\"",
+        "data-number-flow-duration-value=\"#{duration}\"",
+        "data-number-flow-easing-value=\"#{easing}\"",
+        "data-number-flow-stagger-value=\"#{stagger}\"",
+        "data-number-flow-grouping-value=\"#{grouping}\"",
+        "data-number-flow-precision-value=\"#{precision}\""
+      ]
+      data_attrs << "data-number-flow-locale-value=\"#{locale}\"" if locale
+
+      # Build digit spans
+      formatted = format_for_test(value, precision, grouping, locale)
+      inner = formatted.chars.map do |char|
+        if char.match?(/\d/)
+          build_digit_span_html(char.to_i)
+        else
+          %(<span class="nf__separator" aria-hidden="true">#{char}</span>)
+        end
+      end.join
+
+      %(<span class="nf" role="status" aria-live="polite" aria-label="#{formatted}" #{data_attrs.join(' ')}>#{inner}</span>)
+    end
+
+    def format_for_test(value, precision, grouping, locale)
+      sign = value.negative? ? '-' : ''
+      abs = value.abs
+      decimal_sep = locale && !locale.start_with?('en') ? ',' : '.'
+      group_sep = locale && !locale.start_with?('en') ? '.' : ','
+
+      if precision.positive?
+        int_part = Integer(abs.floor)
+        fraction = format('%.0f', (abs - int_part) * (10**precision)).rjust(precision, '0')
+        int_str = grouping ? int_part.to_s.reverse.scan(/.{1,3}/).join(group_sep).reverse : int_part.to_s
+        "#{sign}#{int_str}#{decimal_sep}#{fraction}"
+      else
+        int_str = Integer(abs).to_s
+        int_str = int_str.reverse.scan(/.{1,3}/).join(group_sep).reverse if grouping
+        "#{sign}#{int_str}"
+      end
+    end
+
+    def build_digit_span_html(digit)
+      cells = (0..9).map { |v| %(<span class="nf__cell" aria-hidden="true">#{v}</span>) }.join
+      %(<span class="nf__digit" data-digit="#{digit}"><span class="nf__track" data-to-digit="#{digit}" style="--nf-current-digit: #{digit}; --nf-from-digit: #{digit}; --nf-to-digit: #{digit};">#{cells}</span></span>)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Addresses all seven open GitHub issues in a single cohesive PR, implementing real-number animation, locale-aware formatting, CI, Vite integration, ViewComponent wrapper, browser system tests, and the npm distribution decision.

Fixes #1 — Decimal/fractional number animation support
Fixes #2 — Locale-aware formatting via Intl.NumberFormat
Fixes #3 — Real browser system tests for animation behavior
Fixes #4 — Set up GitHub Actions CI for test + lint
Fixes #5 — Provide optional ViewComponent API wrapper
Fixes #6 — Evaluate optional npm distribution (decision: gem-only)
Fixes #7 — Add first-class Vite Rails integration

## Changes by Issue

### #1 — Decimal/fractional animation
- Rewrote `lib/number_flow/helper.rb`: `Integer(value)` → `coerce_number` (Float/Integer/String), added `precision:` option + `number_flow_precision_value` data attribute (only emitted when precision > 0)
- Rewrote `app/assets/javascripts/number_flow/controller.js`: `Intl.NumberFormat` formatting, removed all `Math.trunc`, added `precision` and `locale` to `static values`
- `precision: 0` (default) produces **byte-identical** integer output to the original gem (no precision data attribute emitted)

### #2 — Locale-aware formatting
- Ruby SSR: locale-specific group/decimal separators (`de-DE` → `1.234,5`)
- JS runtime: `Intl.NumberFormat` with `useGrouping`, `minimumFractionDigits`, `maximumFractionDigits`
- Tested for `en-US` (`1,234.5`) and `de-DE` (`1.234,5`)

### #3 — Real browser system tests
- 7 Cuprite (headless Chrome) system tests in `test/system/animation_test.rb`
- Tests: update/final digits (integer), multi-digit, decimal update, `9.99→10.00` rollover, **reduced-motion** (no animated track class), negative values, `de-DE` locale formatting
- Gated behind `RUN_SYSTEM_TESTS=true` env var
- **CI GREEN**: Browser System Tests job passes on GitHub Actions (Chrome 136 pinned, `--no-sandbox`, 30s process_timeout)

### #4 — CI workflow
- `.github/workflows/ci.yml` with two jobs:
  - **Tests + Lint**: `bundle exec rake test` + `bundle exec rubocop` (11s)
  - **Browser System Tests**: browser system tests with `setup-chrome` action (39s)
- Triggers on PR and push to master
- **Both jobs GREEN on CI**

### #5 — Optional ViewComponent wrapper
- `app/components/number_flow/component.rb`: `NumberFlow::Component < ViewComponent::Base`
- Soft `require 'view_component'` — only defined when gem present
- NOT added to `spec.add_dependency`; only in Gemfile `:test` group
- 4 component tests verify identical markup to helper

### #6 — npm distribution decision
- README "Why No npm Package?" section with rationale: controller depends on helper markup contract, dual release doubles maintenance, Vite generator solves asset resolution
- Decision: **gem-only**. Revisit trigger documented.

### #7 — Vite Rails integration generator
- `lib/generators/number_flow/install/install_generator.rb`
- `rails g number_flow:install --vite`: copies controller + CSS to `app/frontend/`, appends registration to entrypoint
- **Idempotent**: re-running does not duplicate import/register lines
- **Non-destructive**: without `--vite`, prints Sprockets/importmap docs, copies nothing
- 6 generator tests including `test_generator_loaded_via_require_number_flow` (catches dead require path regressions)

## Verification Evidence (head `1981e67`)

### `bundle exec rake test` (unit/integration/generator/component — no system tests)
```
32 runs, 147 assertions, 0 failures, 0 errors, 0 skips
```

### `bundle exec rubocop`
```
18 files inspected, no offenses detected
```

### `RUN_SYSTEM_TESTS=true bundle exec rake test` (with browser tests)
```
39 runs, 165 assertions, 0 failures, 0 errors, 0 skips
```
All 7 system tests pass with Chromium 148 headless (local) and Chrome 136 (CI).

### `gem build number_flow.gemspec`
```
Successfully built RubyGem: number_flow-0.1.2.gem
```

### GitHub Actions CI (run 29213859842)
```
Tests + Lint        pass   11s
Browser System Tests pass   39s
```
**Both jobs GREEN.**

## Acceptance Fixes Applied (from review feedback)

1. **CI browser reliability**: Root cause was Ferrum 0.17's default `process_timeout` (10s) insufficient for Chromium 152 on CI runners, plus CI running as root requiring `--no-sandbox`. Fixed by: pinning Chrome 136, adding `--no-sandbox --disable-gpu --disable-dev-shm-usage` browser options, increasing `process_timeout` to 30s.
2. **Dead require_relative path**: Fixed `lib/number_flow.rb` path from `'../generators'` (resolved outside lib/) to `'generators'` (correct). Removed direct require in test so the regression test catches path bugs via the normal load path.
3. **Byte-identical integer output**: Now omit `data-number-flow-precision-value` when `precision=0` (default). Integer call sites produce byte-identical output to the original gem. Stimulus defaults `precisionValue` to 0 when attribute absent.

## Changed Files (17 files total)

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | **New** — CI with test+lint and browser system test jobs (Chrome 136, no-sandbox, 30s timeout) |
| `.rubocop.yml` | Updated limits for new module/class sizes |
| `Gemfile` | Added `:test` group: capybara, cuprite, view_component, webrick |
| `Gemfile.lock` | Updated lockfile |
| `README.md` | New: decimal/locale/precision API docs, Vite section, ViewComponent section, npm decision doc |
| `app/assets/javascripts/number_flow/controller.js` | Rewritten: Intl.NumberFormat, precision/locale values, guard for pre-connect |
| `app/components/number_flow/component.rb` | **New** — optional ViewComponent wrapper |
| `lib/generators/number_flow/install/install_generator.rb` | **New** — Vite/Sprockets install generator |
| `lib/number_flow.rb` | Fixed generator require path; load component + generators when available |
| `lib/number_flow/helper.rb` | Rewritten: decimal/precision/locale support; omit precision=0 attr |
| `test/components/component_test.rb` | **New** — 4 ViewComponent tests |
| `test/generators/install_generator_test.rb` | **New** — 6 generator tests (idempotency, Vite, standard, require path regression) |
| `test/number_flow/controller_contract_test.rb` | Added precision + locale contract assertions |
| `test/number_flow/helper_test.rb` | Added 8 tests: decimals, precision, locale, true byte-identical regression |
| `test/system/animation_test.rb` | **New** — 7 browser system tests |
| `test/system/support/stimulus.js` | **New** — vendored Stimulus UMD for browser tests |
| `test/system/test_support.rb` | **New** — Cuprite driver setup (no-sandbox, 30s timeout) + HTML page builder |

## Constraints Honored

- No version bump (stays 0.1.2; release deferred)
- No npm package publishing
- ViewComponent optional (no runtime dependency)
- **Integer helper output is byte-identical to original gem** (no extra data attributes when precision=0)
- Vite generator idempotent and non-destructive
- TDD approach throughout
- Generator require path fixed and regression-tested