### PR TITLE
chore: release 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,15 @@ on:
 
 jobs:
   test:
-    name: Tests + Lint
+    name: Tests + Lint (Ruby ${{ matrix.ruby }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "3.4"
+          - "3.5"
+          - "4.0"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,7 +25,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         ruby:
           - "3.4"
-          - "3.5"
           - "4.0"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,24 @@
-name: Release Gem
+name: Release
 
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   release:
-    name: Release gem to RubyGems.org
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
 
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"
           bundler-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-13
+
+### Added
+- Decimal and fractional number animations with configurable precision and rollover behavior.
+- Locale-aware number formatting powered by `Intl.NumberFormat`.
+- Optional `NumberFlow::Component` integration and a Vite installer generator.
+- Chromium/Cuprite browser coverage and continuous integration for browser behavior.
+
+### Changed
+- Improved negative-number and reduced-motion animation behavior.
+- Documented the decision to keep Number Flow distributed as a Ruby gem.
+
 ## [0.1.2] - 2026-07-12
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    number_flow (0.1.2)
+    number_flow (0.2.0)
       actionview (>= 8.1.0)
       railties (>= 8.1.0)
 
@@ -321,7 +321,7 @@ CHECKSUMS
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
   nokogiri (1.19.2-arm64-darwin) sha256=58d8ea2e31a967b843b70487a44c14c8ba1866daa1b9da9be9dbdf1b43dee205
   nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
-  number_flow (0.1.2)
+  number_flow (0.2.0)
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.2) sha256=6f60c84aa4bdcedb6d1a2434b738fe8a8136807b6adc8f7f53b97da9bc4e9357
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6

--- a/lib/number_flow/version.rb
+++ b/lib/number_flow/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NumberFlow
-  VERSION = '0.1.2'
+  VERSION = '0.2.0'
 end

--- a/number_flow.gemspec
+++ b/number_flow.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new do |spec|
   spec.authors = ['dpaluy']
   spec.email = ['dpaluy@users.noreply.github.com']
 
-  spec.summary = 'Rails helper + Stimulus digit flow transitions for integers.'
-  spec.description = 'NumberFlow provides a Rails helper and Stimulus controller for smooth integer digit ' \
-                     'transitions using gem-shipped CSS and JavaScript assets.'
+  spec.summary = 'Rails helper + Stimulus transitions for animated numbers.'
+  spec.description = 'NumberFlow provides a Rails helper and Stimulus controller for smooth, locale-aware ' \
+                     'number transitions using gem-shipped CSS and JavaScript assets.'
   spec.homepage = 'https://github.com/dpaluy/number_flow#readme'
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.4.0'


### PR DESCRIPTION
## Summary

- release Number Flow 0.2.0 with decimal, locale, component, generator, and browser-test features from #18
- adopt the canonical trusted-publishing `release.yml` used by the other managed gems
- test the supported Ruby range on Ruby 3.4, 3.5, and 4.0
- update gem metadata and lockfile for 0.2.0

## Verification

- `bundle exec rake test` — 32 runs, 147 assertions, 0 failures
- `RUN_SYSTEM_TESTS=true bundle exec rake test` — 39 runs, 165 assertions, 0 failures
- `bundle exec rubocop` — 18 files, no offenses
- `gem build number_flow.gemspec` — built `number_flow-0.2.0.gem`
- `git diff --check` — passed

Closes the release follow-up to #18.
